### PR TITLE
build: bump prow version

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -6,7 +6,7 @@ presubmits:
       - ^main$
     spec:
       containers:
-        - image: gcr.io/k8s-prow/checkconfig:v20201204-d90be1ef6b
+        - image: gcr.io/k8s-prow/checkconfig:v20201217-2de500de27
           command:
             - /checkconfig
           args:
@@ -19,7 +19,7 @@ presubmits:
       - ^main$
     spec:
       containers:
-        - image: gcr.io/k8s-prow/label_sync:v20201204-d90be1ef6b
+        - image: gcr.io/k8s-prow/label_sync:v20201217-2de500de27
           command:
             - /app/label_sync/app.binary
           args:
@@ -101,7 +101,7 @@ postsubmits:
       - ^main$
     spec:
       containers:
-        - image: gcr.io/k8s-prow/label_sync:v20201204-d90be1ef6b
+        - image: gcr.io/k8s-prow/label_sync:v20201217-2de500de27
           command:
             - /app/label_sync/app.binary
           args:

--- a/prow/cluster/branchprotector.yaml
+++ b/prow/cluster/branchprotector.yaml
@@ -15,7 +15,7 @@ spec:
         spec:
           containers:
             - name: branchprotector
-              image: gcr.io/k8s-prow/branchprotector:v20201204-d90be1ef6b
+              image: gcr.io/k8s-prow/branchprotector:v20201217-2de500de27
               args:
                 - --config-path=/etc/config/config.yaml
                 - --github-token-path=/etc/github/token

--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: crier
-          image: gcr.io/k8s-prow/crier:v20201204-d90be1ef6b
+          image: gcr.io/k8s-prow/crier:v20201217-2de500de27
           args:
             - --blob-storage-workers=10
             - --config-path=/etc/config/config.yaml

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: deck
-          image: gcr.io/k8s-prow/deck:v20201204-d90be1ef6b
+          image: gcr.io/k8s-prow/deck:v20201217-2de500de27
           args:
             - --config-path=/etc/config/config.yaml
             - --plugin-config=/etc/plugins/plugins.yaml

--- a/prow/cluster/ghproxy.yaml
+++ b/prow/cluster/ghproxy.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
         - name: ghproxy
-          image: gcr.io/k8s-prow/ghproxy:v20201204-d90be1ef6b
+          image: gcr.io/k8s-prow/ghproxy:v20201217-2de500de27
           args:
             - --cache-dir=/cache
             - --cache-sizeGB=1

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -24,7 +24,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: hook
-          image: gcr.io/k8s-prow/hook:v20201204-d90be1ef6b
+          image: gcr.io/k8s-prow/hook:v20201217-2de500de27
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -21,7 +21,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
         - name: horologium
-          image: gcr.io/k8s-prow/horologium:v20201204-d90be1ef6b
+          image: gcr.io/k8s-prow/horologium:v20201217-2de500de27
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/prow/cluster/needs-rebase_deployment.yaml
+++ b/prow/cluster/needs-rebase_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: needs-rebase
-          image: gcr.io/k8s-prow/needs-rebase:v20201204-d90be1ef6b
+          image: gcr.io/k8s-prow/needs-rebase:v20201217-2de500de27
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/plank_deployment.yaml
+++ b/prow/cluster/plank_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: plank
       containers:
       - name: plank
-        image: gcr.io/k8s-prow/plank:v20201204-d90be1ef6b
+        image: gcr.io/k8s-prow/plank:v20201217-2de500de27
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/cluster/prow_controller_manager_deployment.yaml
+++ b/prow/cluster/prow_controller_manager_deployment.yaml
@@ -25,7 +25,7 @@ spec:
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
             - --enable-controller=plank
-          image: gcr.io/k8s-prow/prow-controller-manager:v20201204-d90be1ef6b
+          image: gcr.io/k8s-prow/prow-controller-manager:v20201217-2de500de27
           volumeMounts:
             - name: github-token
               mountPath: /etc/github

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       serviceAccountName: "sinker"
       containers:
         - name: sinker
-          image: gcr.io/k8s-prow/sinker:v20201204-d90be1ef6b
+          image: gcr.io/k8s-prow/sinker:v20201217-2de500de27
           args:
             - --config-path=/etc/config/config.yaml
           volumeMounts:

--- a/prow/cluster/statusreconciler_deployment.yaml
+++ b/prow/cluster/statusreconciler_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: statusreconciler
-          image: gcr.io/k8s-prow/status-reconciler:v20201204-d90be1ef6b
+          image: gcr.io/k8s-prow/status-reconciler:v20201217-2de500de27
           args:
             - --dry-run=false
             - --continue-on-error=true

--- a/prow/cluster/ti_community_autoresponder_deployment.yaml
+++ b/prow/cluster/ti_community_autoresponder_deployment.yaml
@@ -37,7 +37,7 @@ spec:
               mountPath: /etc/github
               readOnly: true
             - name: external-plugins-config
-              mountPath: /etc/plugins
+              mountPath: /etc/external_plugins_config
               readOnly: true
           livenessProbe:
             httpGet:

--- a/prow/cluster/ti_community_autoresponder_deployment.yaml
+++ b/prow/cluster/ti_community_autoresponder_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-autoresponder
-          image: rustinliu/ti-community-prow-autoresponder-plugin:v0.16.1
+          image: rustinliu/ti-community-prow-autoresponder-plugin:v0.16.5
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_blunderbuss_deployment.yaml
+++ b/prow/cluster/ti_community_blunderbuss_deployment.yaml
@@ -37,7 +37,7 @@ spec:
               mountPath: /etc/github
               readOnly: true
             - name: external-plugins-config
-              mountPath: /etc/plugins
+              mountPath: /etc/external_plugins_config
               readOnly: true
           livenessProbe:
             httpGet:

--- a/prow/cluster/ti_community_blunderbuss_deployment.yaml
+++ b/prow/cluster/ti_community_blunderbuss_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-blunderbuss
-          image: rustinliu/ti-community-prow-blunderbuss-plugin:v0.16.1
+          image: rustinliu/ti-community-prow-blunderbuss-plugin:v0.16.5
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_label_deployment.yaml
+++ b/prow/cluster/ti_community_label_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-label
-          image: rustinliu/ti-community-prow-label-plugin:v0.16.1
+          image: rustinliu/ti-community-prow-label-plugin:v0.16.5
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_label_deployment.yaml
+++ b/prow/cluster/ti_community_label_deployment.yaml
@@ -37,7 +37,7 @@ spec:
               mountPath: /etc/github
               readOnly: true
             - name: external-plugins-config
-              mountPath: /etc/plugins
+              mountPath: /etc/external_plugins_config
               readOnly: true
           livenessProbe:
             httpGet:

--- a/prow/cluster/ti_community_lgtm_deployment.yaml
+++ b/prow/cluster/ti_community_lgtm_deployment.yaml
@@ -37,7 +37,7 @@ spec:
               mountPath: /etc/github
               readOnly: true
             - name: external-plugins-config
-              mountPath: /etc/plugins
+              mountPath: /etc/external_plugins_config
               readOnly: true
           livenessProbe:
             httpGet:

--- a/prow/cluster/ti_community_lgtm_deployment.yaml
+++ b/prow/cluster/ti_community_lgtm_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-lgtm
-          image: rustinliu/ti-community-prow-lgtm-plugin:v0.16.1
+          image: rustinliu/ti-community-prow-lgtm-plugin:v0.16.5
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_merge_deployment.yaml
+++ b/prow/cluster/ti_community_merge_deployment.yaml
@@ -37,7 +37,7 @@ spec:
               mountPath: /etc/github
               readOnly: true
             - name: external-plugins-config
-              mountPath: /etc/plugins
+              mountPath: /etc/external_plugins_config
               readOnly: true
           livenessProbe:
             httpGet:

--- a/prow/cluster/ti_community_merge_deployment.yaml
+++ b/prow/cluster/ti_community_merge_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-merge
-          image: rustinliu/ti-community-prow-merge-plugin:v0.16.1
+          image: rustinliu/ti-community-prow-merge-plugin:v0.16.5
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_owners_deployment.yaml
+++ b/prow/cluster/ti_community_owners_deployment.yaml
@@ -37,7 +37,7 @@ spec:
               mountPath: /etc/github
               readOnly: true
             - name: external-plugins-config
-              mountPath: /etc/plugins
+              mountPath: /etc/external_plugins_config
               readOnly: true
           livenessProbe:
             httpGet:

--- a/prow/cluster/ti_community_owners_deployment.yaml
+++ b/prow/cluster/ti_community_owners_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-owners
-          image: rustinliu/ti-community-prow-owners-plugin:v0.16.1
+          image: rustinliu/ti-community-prow-owners-plugin:v0.16.5
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_tars_deployment.yaml
+++ b/prow/cluster/ti_community_tars_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-tars
-          image: rustinliu/ti-community-prow-tars-plugin:v0.16.1
+          image: rustinliu/ti-community-prow-tars-plugin:v0.16.5
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: "tide"
       containers:
         - name: tide
-          image: gcr.io/k8s-prow/tide:v20201204-d90be1ef6b
+          image: gcr.io/k8s-prow/tide:v20201217-2de500de27
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -180,10 +180,10 @@ plank:
         path_strategy: explicit
       gcs_credentials_secret: gcs-credentials
       utility_images:
-        clonerefs: gcr.io/k8s-prow/clonerefs:v20201204-d90be1ef6b
-        entrypoint: gcr.io/k8s-prow/entrypoint:v20201204-d90be1ef6b
-        initupload: gcr.io/k8s-prow/initupload:v20201204-d90be1ef6b
-        sidecar: gcr.io/k8s-prow/sidecar:v20201204-d90be1ef6b
+        clonerefs: gcr.io/k8s-prow/clonerefs:v20201217-2de500de27
+        entrypoint: gcr.io/k8s-prow/entrypoint:v20201217-2de500de27
+        initupload: gcr.io/k8s-prow/initupload:v20201217-2de500de27
+        sidecar: gcr.io/k8s-prow/sidecar:v20201217-2de500de27
 
 tide:
   sync_period: 1m

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -48,25 +48,29 @@ ti-community-owners:
   - repos:
       - tikv/pd
     default_sig_name: scheduling
-    trusted_team_for_owners: maintainers
+    trusted_teams:
+      - maintainers
     sig_endpoint: https://bots.tidb.io/ti-community-bot
     require_lgtm_label_prefix: require-LGT
   - repos:
       - pingcap/tidb-dashboard
     default_sig_name: diagnosis
     default_require_lgtm: 1
-    trusted_team_for_owners: maintainers
+    trusted_teams:
+      - maintainers
     sig_endpoint: https://bots.tidb.io/ti-community-bot
   - repos:
       - pingcap/tidb-operator
     default_sig_name: k8s
-    trusted_team_for_owners: maintainers
+    trusted_teams:
+      - maintainers
     sig_endpoint: https://bots.tidb.io/ti-community-bot
     require_lgtm_label_prefix: require-LGT
   - repos:
       - pingcap/tiup
     default_sig_name: tiup
-    trusted_team_for_owners: maintainers
+    trusted_teams:
+      - maintainers
     sig_endpoint: https://bots.tidb.io/ti-community-bot
     default_require_lgtm: 1
     require_lgtm_label_prefix: require-LGT


### PR DESCRIPTION
Bump version prow version from v20201204-d90be1ef6b to v2020117-2de500de27

And bump plugins version from v0.16.1 to v0.16.5

part of https://github.com/ti-community-infra/configs/issues/63