### PR TITLE
config: add branches configuration item for tidb-operator

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -66,6 +66,9 @@ ti-community-owners:
       - maintainers
     sig_endpoint: https://bots.tidb.io/ti-community-bot
     require_lgtm_label_prefix: require-LGT
+    branches:
+      release-1.1:
+        default_require_lgtm: 1
   - repos:
       - pingcap/tiup
     default_sig_name: tiup


### PR DESCRIPTION
The `release-1.1` branch only require one LGTM.