### PR TITLE
build: bump plugins version from v0.16.5 to v0.16.6

### DIFF
--- a/prow/cluster/ti_community_autoresponder_deployment.yaml
+++ b/prow/cluster/ti_community_autoresponder_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-autoresponder
-          image: rustinliu/ti-community-prow-autoresponder-plugin:v0.16.5
+          image: rustinliu/ti-community-prow-autoresponder-plugin:v0.16.6
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_blunderbuss_deployment.yaml
+++ b/prow/cluster/ti_community_blunderbuss_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-blunderbuss
-          image: rustinliu/ti-community-prow-blunderbuss-plugin:v0.16.5
+          image: rustinliu/ti-community-prow-blunderbuss-plugin:v0.16.6
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_label_deployment.yaml
+++ b/prow/cluster/ti_community_label_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-label
-          image: rustinliu/ti-community-prow-label-plugin:v0.16.5
+          image: rustinliu/ti-community-prow-label-plugin:v0.16.6
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_lgtm_deployment.yaml
+++ b/prow/cluster/ti_community_lgtm_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-lgtm
-          image: rustinliu/ti-community-prow-lgtm-plugin:v0.16.5
+          image: rustinliu/ti-community-prow-lgtm-plugin:v0.16.6
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_merge_deployment.yaml
+++ b/prow/cluster/ti_community_merge_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-merge
-          image: rustinliu/ti-community-prow-merge-plugin:v0.16.5
+          image: rustinliu/ti-community-prow-merge-plugin:v0.16.6
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_owners_deployment.yaml
+++ b/prow/cluster/ti_community_owners_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-owners
-          image: rustinliu/ti-community-prow-owners-plugin:v0.16.5
+          image: rustinliu/ti-community-prow-owners-plugin:v0.16.6
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_tars_deployment.yaml
+++ b/prow/cluster/ti_community_tars_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-tars
-          image: rustinliu/ti-community-prow-tars-plugin:v0.16.5
+          image: rustinliu/ti-community-prow-tars-plugin:v0.16.6
           imagePullPolicy: Always
           args:
             - --dry-run=false


### PR DESCRIPTION
Part of https://github.com/ti-community-infra/configs/issues/63