### PR TITLE
config: disable blunderbuss for tikv

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -293,23 +293,6 @@ ti-community-blunderbuss:
       - ti-community-prow-bot
       - ti-srebot
     require_sig_label: true
-  - repos:
-      - tikv/tikv
-    pull_owners_endpoint: https://prow.tidb.io/ti-community-owners
-    max_request_count: 2
-    exclude_reviewers:
-      # Bots
-      - ti-community-prow-bot
-      - ti-srebot
-      # Maintainers
-      - siddontang
-      - sunxiaoguang
-      - winkyao
-      - zhangjinpeng1987
-      - lidaobing
-      - fredchenbj
-      - BusyJay
-    require_sig_label: true
 
 ti-community-tars:
   - repos:

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -424,10 +424,6 @@ external_plugins:
       events:
         - pull_request
         - issue_comment
-    - name: ti-community-blunderbuss
-      events:
-        - pull_request
-        - issue_comment
     - name: ti-community-autoresponder
       events:
         - issue_comment


### PR DESCRIPTION
Now that PR supports multiple sigs, we need to redesign the plugin.