### PR TITLE
config: uniform commit message format for tikv and pingcap

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -314,13 +314,9 @@ tide:
     ti-community-infra:
       title: "{{ .Title }} (#{{ .Number }})"
       body: "{{ .Body }}"
-    tikv/tikv:
+    tikv:
       title: "{{ .Title }} (#{{ .Number }})"
-      body: "{{ .Body }}"
-    pingcap/tidb:
-      title: "{{ .Title }} (#{{ .Number }})"
-      body: " "
-    pingcap/tidb-operator:
+    pingcap:
       title: "{{ .Title }} (#{{ .Number }})"
       body: " "
 


### PR DESCRIPTION
For pingcap org, the CLA is signed, so we can just set the body to empty.
For tikv org, the DOC will be signed, so to ensure that each DCO is recorded effectively, use the GitHub default squash body.