### PR TITLE
feat: tiup: not marking required checks but wait for all to success

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -107,7 +107,6 @@ branch-protection:
                 contexts:
                   - "license/cla"
                 strict: true
-                skip-unknown-contexts: false
         tidb:
           branches:
             master:
@@ -447,6 +446,7 @@ tide:
             from-branch-protection: true
           tiup:
             from-branch-protection: true
+            skip-unknown-contexts: false
           tidb:
             branches:
               master:

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -105,24 +105,9 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
-                  - "Install"
-                  - "cluster (test_cmd)"
-                  - "cluster (test_scale_core)"
-                  - "dm (--do-cases test_cmd)"
-                  - "playground (test_playground)"
-                  - "tiup (test_tiup)"
-                  - "reprotest (1.16)"
-                  - "cluster (test_upgrade)"
-                  - "cluster (test_scale_tools)"
-                  - "dm (--do-cases test_upgrade)"
-                  - "cluster (test_scale_core_tls)"
-                  - "dm (--native-ssh --do-cases test_cmd)"
-                  - "cluster (test_scale_tools_tls)"
-                  - "dm (--native-ssh --do-cases test_upgrade)"
-                  - "Local Install"
-                  - "unit-test"
                   - "license/cla"
                 strict: true
+                skip-unknown-contexts: false
         tidb:
           branches:
             master:


### PR DESCRIPTION
Close https://github.com/ti-community-infra/tichi/issues/393

As some of PR in TiUP repo may not run all of the CI jobs, just remove required mark for them and let bot wait to all checks to pass before commit merge.