### PR TITLE
config: enable tichi for docs / docs-cn / docs-dm / docs-tidb-operator

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -167,42 +167,42 @@ branch-protection:
                 contexts:
                   - "ci/circleci: lint"
                   - "license/cla"
-                strict: true
+                strict: false
             release-2.1:
               protect: true
               required_status_checks:
                 contexts:
                   - "ci/circleci: lint"
                   - "license/cla"
-                strict: true
+                strict: false
             release-3.0:
               protect: true
               required_status_checks:
                 contexts:
                   - "ci/circleci: lint"
                   - "license/cla"
-                strict: true
+                strict: false
             release-3.1:
               protect: true
               required_status_checks:
                 contexts:
                   - "ci/circleci: lint"
                   - "license/cla"
-                strict: true
+                strict: false
             release-4.0:
               protect: true
               required_status_checks:
                 contexts:
                   - "ci/circleci: lint"
                   - "license/cla"
-                strict: true
+                strict: false
             release-5.0:
               protect: true
               required_status_checks:
                 contexts:
                   - "ci/circleci: lint"
                   - "license/cla"
-                strict: true
+                strict: false
         docs-cn:
           branches:
             master:
@@ -211,42 +211,42 @@ branch-protection:
                 contexts:
                   - "ci/circleci: lint"
                   - "license/cla"
-                strict: true
+                strict: false
             release-2.1:
               protect: true
               required_status_checks:
                 contexts:
                   - "ci/circleci: lint"
                   - "license/cla"
-                strict: true
+                strict: false
             release-3.0:
               protect: true
               required_status_checks:
                 contexts:
                   - "ci/circleci: lint"
                   - "license/cla"
-                strict: true
+                strict: false
             release-3.1:
               protect: true
               required_status_checks:
                 contexts:
                   - "ci/circleci: lint"
                   - "license/cla"
-                strict: true
+                strict: false
             release-4.0:
               protect: true
               required_status_checks:
                 contexts:
                   - "ci/circleci: lint"
                   - "license/cla"
-                strict: true
+                strict: false
             release-5.0:
               protect: true
               required_status_checks:
                 contexts:
                   - "ci/circleci: lint"
                   - "license/cla"
-                strict: true
+                strict: false
         docs-dm:
           branches:
             master:
@@ -255,21 +255,21 @@ branch-protection:
                 contexts:
                   - "ci / pull (pull_request)"
                   - "license/cla"
-                strict: true
+                strict: false
             release-1.0:
               protect: true
               required_status_checks:
                 contexts:
                   - "ci / pull (pull_request)"
                   - "license/cla"
-                strict: true
+                strict: false
             release-2.0:
               protect: true
               required_status_checks:
                 contexts:
                   - "ci / pull (pull_request)"
                   - "license/cla"
-                strict: true
+                strict: false
         pingcap/docs-tidb-operator:
           branches:
             master:
@@ -278,21 +278,21 @@ branch-protection:
                 contexts:
                   - "ci / pull (pull_request)"
                   - "license/cla"
-                strict: true
+                strict: false
             release-1.0:
               protect: true
               required_status_checks:
                 contexts:
                   - "ci / pull (pull_request)"
                   - "license/cla"
-                strict: true
+                strict: false
             release-1.1:
               protect: true
               required_status_checks:
                 contexts:
                   - "ci / pull (pull_request)"
                   - "license/cla"
-                strict: true
+                strict: false
     ti-community-infra:
       repos:
         tichi:

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -504,7 +504,7 @@ tide:
         - do-not-merge/work-in-progress
         - needs-rebase
     - repos:
-        - docs-dm
+        - pingcap/docs-dm
       includedBranches:
         - master
         - release-1.0

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -159,6 +159,140 @@ branch-protection:
                   - "idc-jenkins-ci-tidb/check_release_note"
                   - "license/cla"
                 strict: true
+        docs:
+          branches:
+            master:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - "ci/circleci: lint"
+                  - "license/cla"
+                strict: true
+            release-2.1:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - "ci/circleci: lint"
+                  - "license/cla"
+                strict: true
+            release-3.0:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - "ci/circleci: lint"
+                  - "license/cla"
+                strict: true
+            release-3.1:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - "ci/circleci: lint"
+                  - "license/cla"
+                strict: true
+            release-4.0:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - "ci/circleci: lint"
+                  - "license/cla"
+                strict: true
+            release-5.0:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - "ci/circleci: lint"
+                  - "license/cla"
+                strict: true
+        docs-cn:
+          branches:
+            master:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - "ci/circleci: lint"
+                  - "license/cla"
+                strict: true
+            release-2.1:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - "ci/circleci: lint"
+                  - "license/cla"
+                strict: true
+            release-3.0:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - "ci/circleci: lint"
+                  - "license/cla"
+                strict: true
+            release-3.1:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - "ci/circleci: lint"
+                  - "license/cla"
+                strict: true
+            release-4.0:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - "ci/circleci: lint"
+                  - "license/cla"
+                strict: true
+            release-5.0:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - "ci/circleci: lint"
+                  - "license/cla"
+                strict: true
+        docs-dm:
+          branches:
+            master:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - "ci / pull (pull_request)"
+                  - "license/cla"
+                strict: true
+            release-1.0:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - "ci / pull (pull_request)"
+                  - "license/cla"
+                strict: true
+            release-2.0:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - "ci / pull (pull_request)"
+                  - "license/cla"
+                strict: true
+        pingcap/docs-tidb-operator:
+          branches:
+            master:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - "ci / pull (pull_request)"
+                  - "license/cla"
+                strict: true
+            release-1.0:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - "ci / pull (pull_request)"
+                  - "license/cla"
+                strict: true
+            release-1.1:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - "ci / pull (pull_request)"
+                  - "license/cla"
+                strict: true
     ti-community-infra:
       repos:
         tichi:
@@ -292,7 +426,10 @@ tide:
     pingcap/tidb-dashboard: squash
     pingcap/tidb-operator: squash
     pingcap/tiup: squash
-    pingcap/tidb: squash
+    pingcap/docs: squash
+    pingcap/docs-cn: squash
+    pingcap/docs-dm: squash
+    pingcap/docs-tidb-operator: squash
 
   merge_commit_template:
     ti-community-infra:
@@ -344,6 +481,46 @@ tide:
         - release-3.0
         - release-4.0
         - release-5.0-rc
+      labels:
+        - status/can-merge
+      missingLabels:
+        - do-not-merge/hold
+        - do-not-merge/work-in-progress
+        - needs-rebase
+    - repos:
+        - pingcap/docs
+        - pingcap/docs-cn
+      includedBranches:
+        - master
+        - release-2.1
+        - release-3.0
+        - release-3.1
+        - release-4.0
+        - release-5.0
+      labels:
+        - status/can-merge
+      missingLabels:
+        - do-not-merge/hold
+        - do-not-merge/work-in-progress
+        - needs-rebase
+    - repos:
+        - docs-dm
+      includedBranches:
+        - master
+        - release-1.0
+        - release-2.0
+      labels:
+        - status/can-merge
+      missingLabels:
+        - do-not-merge/hold
+        - do-not-merge/work-in-progress
+        - needs-rebase
+    - repos:
+        - pingcap/docs-tidb-operator
+      includedBranches:
+        - master
+        - release-1.0
+        - release-1.1
       labels:
         - status/can-merge
       missingLabels:
@@ -447,6 +624,18 @@ tide:
           tiup:
             from-branch-protection: true
             skip-unknown-contexts: false
+          docs:
+            skip-unknown-contexts: true
+            from-branch-protection: true
+          docs-cn:
+            skip-unknown-contexts: true
+            from-branch-protection: true
+          docs-dm:
+            skip-unknown-contexts: true
+            from-branch-protection: true
+          docs-tidb-operator:
+            skip-unknown-contexts: true
+            from-branch-protection: true
           tidb:
             branches:
               master:

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -19,6 +19,10 @@ ti-community-lgtm:
       - tikv/community
       - pingcap/community
       - pingcap/tidb
+      - pingcap/docs
+      - pingcap/docs-cn
+      - pingcap/docs-dm
+      - pingcap/docs-tidb-operator
     review_acts_as_lgtm: true
     pull_owners_endpoint: https://prow.tidb.io/ti-community-owners
 
@@ -39,6 +43,10 @@ ti-community-merge:
       - tikv/community
       - pingcap/community
       - pingcap/tidb
+      - pingcap/docs
+      - pingcap/docs-cn
+      - pingcap/docs-dm
+      - pingcap/docs-tidb-operator
     store_tree_hash: true
     pull_owners_endpoint: https://prow.tidb.io/ti-community-owners
 
@@ -140,6 +148,15 @@ ti-community-owners:
   - repos:
       - tikv/community
       - pingcap/community
+    default_require_lgtm: 1
+    sig_endpoint: https://bots.tidb.io/ti-community-bot
+    require_lgtm_label_prefix: require-LGT
+    use_github_permission: true
+  - repos:
+      - pingcap/docs
+      - pingcap/docs-cn
+      - pingcap/docs-dm
+      - pingcap/docs-tidb-operator
     default_require_lgtm: 1
     sig_endpoint: https://bots.tidb.io/ti-community-bot
     require_lgtm_label_prefix: require-LGT
@@ -265,6 +282,119 @@ ti-community-label:
       - 'require-LGT3'
       - 'security'
       - 'tools'
+    exclude_labels:
+      - status/can-merge
+  - repos:
+      - pingcap/docs
+      - pingcap/docs-cn
+    prefixes:
+      - area
+      - closed
+      - lifecycle
+      - priority
+      - size
+      - status
+      - suggestion
+      - translation
+      - type
+      - epic
+    additional_labels:
+      - 'DNM until Ansible tag is ready'
+      - 'Hacktoberfest'
+      - 'contribution'
+      - 'first-time-contributor'
+      - 'follow-up'
+      - 'good-first-issue'
+      - 'hacktoberfest-accepted'
+      - 'help-wanted'
+      - 'needs-cherry-pick-2.1'
+      - 'needs-cherry-pick-3.0'
+      - 'needs-cherry-pick-3.1'
+      - 'needs-cherry-pick-4.0'
+      - 'needs-cherry-pick-5.0'
+      - 'needs-cherry-pick-master'
+      - 'question'
+      - 'require-LGT1'
+      - 'require-LGT2'
+      - 'require-LGT3'
+      - 'special-week'
+      - 'v4.0'
+      - 'v5.0'
+      - 'v6.0'
+      - 'version-specific-changes-required'
+      - 'website'
+    exclude_labels:
+      - status/can-merge
+  - repos:
+      - pingcap/docs-dm
+    prefixes:
+      - area
+      - closed
+      - lifecycle
+      - priority
+      - size
+      - status
+      - suggestion
+      - translation
+      - type
+    additional_labels:
+      - 'DNM until Ansible tag is ready'
+      - 'contribution'
+      - 'dev'
+      - 'first-time-contributor'
+      - 'follow-up'
+      - 'good-first-issue'
+      - 'help-wanted'
+      - 'needs-cherry-pick-1.0'
+      - 'needs-cherry-pick-2.0'
+      - 'needs-cherry-pick-master'
+      - 'question'
+      - 'require-LGT1'
+      - 'require-LGT2'
+      - 'require-LGT3'
+      - 'special-week'
+      - 'v1.0'
+      - 'v2.0'
+      - 'v3.0'
+      - 'version-specific-changes-required'
+      - 'website'
+    exclude_labels:
+      - status/can-merge
+  - repos:
+      - pingcap/docs-tidb-operator
+    prefixes:
+      - area
+      - closed
+      - lifecycle
+      - priority
+      - size
+      - status
+      - suggestion
+      - translation
+      - type
+    additional_labels:
+      - 'DNM until Ansible tag is ready'
+      - 'Hacktoberfest'
+      - 'contribution'
+      - 'dev'
+      - 'first-time-contributor'
+      - 'follow-up'
+      - 'good-first-issue'
+      - 'hacktoberfest-accepted'
+      - 'help-wanted'
+      - 'needs-cherry-pick-1.0'
+      - 'needs-cherry-pick-1.1'
+      - 'needs-cherry-pick-master'
+      - 'question'
+      - 'require-LGT1'
+      - 'require-LGT2'
+      - 'require-LGT3'
+      - 'special-week'
+      - 'v1.0'
+      - 'v1.1'
+      - 'v1.2'
+      - 'version-specific-changes-required'
+      - 'website'
     exclude_labels:
       - status/can-merge
 
@@ -405,6 +535,10 @@ ti-community-label-blocker:
   - repos:
       - tikv/tikv
       - pingcap/tidb
+      - pingcap/docs
+      - pingcap/docs-cn
+      - pingcap/docs-dm
+      - pingcap/docs-tidb-operator
     block_labels:
       - regex: "^status/LGT[\\d]+$"
         actions:
@@ -424,4 +558,23 @@ ti-community-label-blocker:
           - unlabeled
         trusted_teams:
           - qa-release-merge
+        trusted_users:
+          - ti-chi-bot
+  - repos:
+      - pingcap/docs
+      - pingcap/docs-cn
+      - pingcap/docs-dm
+      - pingcap/docs-tidb-operator
+    block_labels:
+      - regex: "^status/LGT[\\d]+$"
+        actions:
+          - labeled
+          - unlabeled
+        trusted_users:
+          - ti-chi-bot
+      - regex: "^status/can-merge$"
+        actions:
+          - labeled
+          - unlabeled
+        trusted_users:
           - ti-chi-bot

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -17,6 +17,10 @@ welcome:
       - ti-community-infra
       - tikv/tikv
       - pingcap/tidb
+      - pingcap/docs
+      - pingcap/docs-cn
+      - pingcap/docs-tidb-operator
+      - pingcap/docs-dm
     message_template: "Welcome @{{.AuthorLogin}}! <br><br>It looks like this is your first PR to <a href='https://github.com/{{.Org}}/{{.Repo}}'>{{.Org}}/{{.Repo}}</a> 🎉. <br><br>I'm the bot to help you request reviewers, add labels and more, See [available commands](https://prow.tidb.io/command-help). <br><br>We want to make sure your contribution gets all the attention it needs! <br><br> <br><br>Thank you, and welcome to {{.Org}}/{{.Repo}}. :smiley:"
 
 size:
@@ -43,6 +47,27 @@ require_matching_label:
     missing_comment: |
       There are no type labels on this issue. Please add an appropriate label by using the following command:
       - `/type <type-name>`
+  - missing_label: missing-translation-status
+    org: pingcap
+    repo: docs
+    prs: true
+    regexp: ^translation/
+  - missing_label: missing-translation-status
+    org: pingcap
+    repo: docs-cn
+    prs: true
+    regexp: ^translation/
+  - missing_label: missing-translation-status
+    org: pingcap
+    repo: docs-dm
+    prs: true
+    regexp: ^translation/
+  - missing_label: missing-translation-status
+    org: pingcap
+    repo: docs-tidb-operator
+    prs: true
+    regexp: ^translation/
+
 
 repo_milestone:
   ti-community-infra/tichi:
@@ -164,6 +189,34 @@ plugins:
     - size
     - lifecycle
     - welcome
+  pingcap/docs:
+    - welcome
+    - assign
+    - hold
+    - wip
+    - size
+    - require-matching-label
+  pingcap/docs-cn:
+    - welcome
+    - assign
+    - hold
+    - wip
+    - size
+    - require-matching-label
+  pingcap/docs-tidb-operator:
+    - welcome
+    - assign
+    - hold
+    - wip
+    - size
+    - require-matching-label
+  pingcap/docs-dm:
+    - welcome
+    - assign
+    - hold
+    - wip
+    - size
+    - require-matching-label
 
 external_plugins:
   ti-community-infra/test-live:
@@ -546,6 +599,94 @@ external_plugins:
         - pull_request
         - issue_comment
         - push
+    - name: ti-community-label
+      events:
+        - issue_comment
+    - name: ti-community-label-blocker
+      events:
+        - pull_request
+  pingcap/docs:
+    - name: ti-community-lgtm
+      events:
+        - issue_comment
+        - pull_request_review_comment
+        - pull_request_review
+        - pull_request
+    - name: ti-community-merge
+      events:
+        - issue_comment
+        - pull_request_review_comment
+        - pull_request
+    - name: needs-rebase
+      events:
+        - pull_request
+        - issue_comment
+    - name: ti-community-label
+      events:
+        - issue_comment
+    - name: ti-community-label-blocker
+      events:
+        - pull_request
+  pingcap/docs-cn:
+    - name: ti-community-lgtm
+      events:
+        - issue_comment
+        - pull_request_review_comment
+        - pull_request_review
+        - pull_request
+    - name: ti-community-merge
+      events:
+        - issue_comment
+        - pull_request_review_comment
+        - pull_request
+    - name: needs-rebase
+      events:
+        - pull_request
+        - issue_comment
+    - name: ti-community-label
+      events:
+        - issue_comment
+    - name: ti-community-label-blocker
+      events:
+        - pull_request
+  pingcap/docs-dm:
+    - name: ti-community-lgtm
+      events:
+        - issue_comment
+        - pull_request_review_comment
+        - pull_request_review
+        - pull_request
+    - name: ti-community-merge
+      events:
+        - issue_comment
+        - pull_request_review_comment
+        - pull_request
+    - name: needs-rebase
+      events:
+        - pull_request
+        - issue_comment
+    - name: ti-community-label
+      events:
+        - issue_comment
+    - name: ti-community-label-blocker
+      events:
+        - pull_request
+  pingcap/docs-tidb-operator:
+    - name: ti-community-lgtm
+      events:
+        - issue_comment
+        - pull_request_review_comment
+        - pull_request_review
+        - pull_request
+    - name: ti-community-merge
+      events:
+        - issue_comment
+        - pull_request_review_comment
+        - pull_request
+    - name: needs-rebase
+      events:
+        - pull_request
+        - issue_comment
     - name: ti-community-label
       events:
         - issue_comment


### PR DESCRIPTION
### Related 

close #151 

### Related repository

- pingcap/docs
- pingcap/docs-cn
- pingcap/docs-tidb-operator
- pingcap/docs-dm

### Enable Plugin
- ti-community-lgtm
- ti-community-merge
- ti-community-owners (By default, PR must have at least one lgtm)
- ti-community-label
- welcome
- assign
- hold
- wip
- size (Use the size plugin to automatically add size label to PR, replaces the original size label manually added)
- require-matching-label (All PRs need to add translation/* label)

