### PR TITLE
config: freeze release-4.0 for tidb/tikv and cleanup the docs repositories query

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -505,6 +505,10 @@ tide:
         - pingcap/community
         - tikv/community
         - tikv/pd
+        - pingcap/docs
+        - pingcap/docs-cn
+        - pingcap/docs-dm
+        - pingcap/docs-tidb-operator
       labels:
         - status/can-merge
       missingLabels:
@@ -527,41 +531,13 @@ tide:
         - do-not-merge/work-in-progress
         - needs-rebase
     - repos:
-        - pingcap/docs
-        - pingcap/docs-cn
+        - tikv/tikv
+        - pingcap/tidb
       includedBranches:
-        - master
-        - release-2.1
-        - release-3.0
-        - release-3.1
         - release-4.0
-        - release-5.0
       labels:
         - status/can-merge
-      missingLabels:
-        - do-not-merge/hold
-        - do-not-merge/work-in-progress
-        - needs-rebase
-    - repos:
-        - pingcap/docs-dm
-      includedBranches:
-        - master
-        - release-1.0
-        - release-2.0
-      labels:
-        - status/can-merge
-      missingLabels:
-        - do-not-merge/hold
-        - do-not-merge/work-in-progress
-        - needs-rebase
-    - repos:
-        - pingcap/docs-tidb-operator
-      includedBranches:
-        - master
-        - release-1.0
-        - release-1.1
-      labels:
-        - status/can-merge
+        - cherry-pick-approved
       missingLabels:
         - do-not-merge/hold
         - do-not-merge/work-in-progress


### PR DESCRIPTION
Actually we don't need to query the docs repository separately.