### PR TITLE
config: cancel freeze release-4.0 for tidb/tikv

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -522,21 +522,10 @@ tide:
         - master
         - release-2.1
         - release-3.0
+        - release-4.0
         - release-5.0-rc
       labels:
         - status/can-merge
-      missingLabels:
-        - do-not-merge/hold
-        - do-not-merge/work-in-progress
-        - needs-rebase
-    - repos:
-        - tikv/tikv
-        - pingcap/tidb
-      includedBranches:
-        - release-4.0
-      labels:
-        - status/can-merge
-        - cherry-pick-approved
       missingLabels:
         - do-not-merge/hold
         - do-not-merge/work-in-progress


### PR DESCRIPTION
Cancel freeze release-4.0 for pingcap/tidb and tikv/tikv. The cherry-pick-approved label is no longer required for the release-4.0 branch.