### PR TITLE
config: enable lifecycle and require-matching-label ignore PR with -cherry-pick label for docs repo

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -321,7 +321,6 @@ ti-community-label:
     prefixes:
       - area
       - closed
-      - lifecycle
       - priority
       - size
       - status
@@ -361,7 +360,6 @@ ti-community-label:
     prefixes:
       - area
       - closed
-      - lifecycle
       - priority
       - size
       - status
@@ -396,7 +394,6 @@ ti-community-label:
     prefixes:
       - area
       - closed
-      - lifecycle
       - priority
       - size
       - status

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -196,6 +196,7 @@ plugins:
     - wip
     - size
     - require-matching-label
+    - lifecycle
   pingcap/docs-cn:
     - welcome
     - assign
@@ -203,6 +204,7 @@ plugins:
     - wip
     - size
     - require-matching-label
+    - lifecycle
   pingcap/docs-tidb-operator:
     - welcome
     - assign
@@ -210,6 +212,7 @@ plugins:
     - wip
     - size
     - require-matching-label
+    - lifecycle
   pingcap/docs-dm:
     - welcome
     - assign
@@ -217,6 +220,7 @@ plugins:
     - wip
     - size
     - require-matching-label
+    - lifecycle
 
 external_plugins:
   ti-community-infra/test-live:

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -51,22 +51,22 @@ require_matching_label:
     org: pingcap
     repo: docs
     prs: true
-    regexp: ^translation/
+    regexp: (^translation/)|(type/(.*)-cherry-pick$)
   - missing_label: missing-translation-status
     org: pingcap
     repo: docs-cn
     prs: true
-    regexp: ^translation/
+    regexp: (^translation/)|(type/(.*)-cherry-pick$)
   - missing_label: missing-translation-status
     org: pingcap
     repo: docs-dm
     prs: true
-    regexp: ^translation/
+    regexp: (^translation/)|(type/(.*)-cherry-pick$)
   - missing_label: missing-translation-status
     org: pingcap
     repo: docs-tidb-operator
     prs: true
-    regexp: ^translation/
+    regexp: (^translation/)|(type/(.*)-cherry-pick$)
 
 
 repo_milestone:


### PR DESCRIPTION
Add lifecycle plugin for the repository: pingcap/docs、pingcap/docs-cn、pingcap/docs-dm、pingcap/docs-tidb-operator.

At the same time, in order to avoid conflicts, cancel the response of the ti-community-label plugin to the `/lifecycle` command prefix.

You can view related commands through [Command Help](https://prow.tidb.io/command-help#close).