### PR TITLE
config: add restrictions to tikv and tidb release branchs

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -90,6 +90,9 @@ branch-protection:
                   - "DCO"
                   - "idc-jenkins-ci/test"
                 strict: true
+              restrictions:
+                users:
+                  - ti-chi-bot
             release-3.0:
               protect: true
               required_status_checks:
@@ -97,6 +100,9 @@ branch-protection:
                   - "DCO"
                   - "idc-jenkins-ci/test"
                 strict: true
+              restrictions:
+                users:
+                  - ti-chi-bot
             release-4.0:
               protect: true
               required_status_checks:
@@ -104,6 +110,9 @@ branch-protection:
                   - "DCO"
                   - "idc-jenkins-ci/test"
                 strict: true
+              restrictions:
+                users:
+                  - ti-chi-bot
             release-5.0-rc:
               protect: true
               required_status_checks:
@@ -111,6 +120,9 @@ branch-protection:
                   - "DCO"
                   - "idc-jenkins-ci/test"
                 strict: true
+              restrictions:
+                users:
+                  - ti-chi-bot
             release-5.0:
               protect: true
               required_status_checks:
@@ -118,6 +130,9 @@ branch-protection:
                   - "DCO"
                   - "idc-jenkins-ci/test"
                 strict: true
+              restrictions:
+                users:
+                  - ti-chi-bot
     pingcap:
       repos:
         community:

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -199,6 +199,9 @@ branch-protection:
                   - "idc-jenkins-ci-tidb/check_release_note"
                   - "license/cla"
                 strict: true
+              restrictions:
+                users:
+                  - ti-chi-bot
             release-3.0:
               protect: true
               required_status_checks:
@@ -219,6 +222,9 @@ branch-protection:
                   - "idc-jenkins-ci-tidb/check_release_note"
                   - "license/cla"
                 strict: true
+              restrictions:
+                users:
+                  - ti-chi-bot
             release-5.0-rc:
               protect: true
               required_status_checks:
@@ -229,6 +235,9 @@ branch-protection:
                   - "idc-jenkins-ci-tidb/check_release_note"
                   - "license/cla"
                 strict: true
+              restrictions:
+                users:
+                  - ti-chi-bot
             release-5.0:
               protect: true
               required_status_checks:
@@ -239,6 +248,9 @@ branch-protection:
                   - "idc-jenkins-ci-tidb/check_release_note"
                   - "license/cla"
                 strict: true
+              restrictions:
+                users:
+                  - ti-chi-bot
         docs:
           branches:
             master:

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -212,6 +212,9 @@ branch-protection:
                   - "idc-jenkins-ci-tidb/check_release_note"
                   - "license/cla"
                 strict: true
+              restrictions:
+                users:
+                  - ti-chi-bot
             release-4.0:
               protect: true
               required_status_checks:


### PR DESCRIPTION
For the release branch, we want to strictly restrict push permissions.