### PR TITLE
config: remove some useless labels

### DIFF
--- a/prow/config/labels.yaml
+++ b/prow/config/labels.yaml
@@ -573,25 +573,6 @@ repos:
         addedBy: anyone
   ti-community-infra/devstats-dev-guide:
     labels:
-      - color: e11d21
-        description: Categorizes issue or PR as related to a bug.
-        name: type/bug
-        previously:
-          - name: bug
-        target: both
-        prowPlugin: ti-community-label
-        isExternalPlugin: true
-        addedBy: anyone
-      - color: c7def8
-        description: Categorizes issue or PR as related to a new feature.
-        name: type/feature
-        previously:
-          - name: enhancement
-          - name: type/enhancement
-        target: both
-        prowPlugin: ti-community-label
-        isExternalPlugin: true
-        addedBy: anyone
       - name: type/design
         color: 0052cc
         description: The issue or PR is related to design.
@@ -616,13 +597,6 @@ repos:
       - name: type/question
         color: 0052cc
         description: The issue belongs to a question.
-        target: issues
-        prowPlugin: ti-community-label
-        isExternalPlugin: true
-        addedBy: anyone
-      - name: type/wontfix
-        color: "e6e6e6"
-        description: "The issue won't be fixed."
         target: issues
         prowPlugin: ti-community-label
         isExternalPlugin: true


### PR DESCRIPTION
I don't think this repository uses these labels.