### PR TITLE
config: enable retitle for docs sig repos

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -223,6 +223,7 @@ plugins:
     - size
     - require-matching-label
     - lifecycle
+    - retitle
   pingcap/docs-cn:
     - welcome
     - assign
@@ -231,6 +232,7 @@ plugins:
     - size
     - require-matching-label
     - lifecycle
+    - retitle
   pingcap/docs-tidb-operator:
     - welcome
     - assign
@@ -239,6 +241,7 @@ plugins:
     - size
     - require-matching-label
     - lifecycle
+    - retitle
   pingcap/docs-dm:
     - welcome
     - assign
@@ -247,6 +250,7 @@ plugins:
     - size
     - require-matching-label
     - lifecycle
+    - retitle
   pingcap/dumpling:
     - welcome
     - assign


### PR DESCRIPTION
Signed-off-by: Ran <huangran@pingcap.com>

The retitle plugin allows users to re-title pull requests and issues where GitHub permissions don't allow them to.