### PR TITLE
config: set tars update period to 2h

### DIFF
--- a/prow/cluster/ti_community_tars_deployment.yaml
+++ b/prow/cluster/ti_community_tars_deployment.yaml
@@ -26,6 +26,7 @@ spec:
             - --github-token-path=/etc/github/token
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
+            - --update-period=2h
           ports:
             - name: http
               containerPort: 80


### PR DESCRIPTION
Because tidb's tests are unstable and accumulate a large number of PRs that can be merged, the regular update time is adjusted to reduce the pressure of CI's tests.