### PR TITLE
config: adjust the updated time to 25m for tidb retester

### DIFF
--- a/prow/jobs/pingcap/tidb/tidb-bot-periodics.yaml
+++ b/prow/jobs/pingcap/tidb/tidb-bot-periodics.yaml
@@ -24,7 +24,7 @@ periodics:
               repo:pingcap/tidb
               sort:created-asc
               base:master
-            - --updated=1h
+            - --updated=25m
             - --token=/etc/github/token
             - |-
               --comment=/run-all-tests


### PR DESCRIPTION
Since the update period of tars is adjusted to 20m, it needs to be adjusted.