### PR TITLE
config: add qiancai for auto-cc of docs-tidb-operator

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -899,6 +899,7 @@ ti-community-blunderbuss:
       - junlan-zhang
       - glkappe
       - Joyinqin
+      - qiancai
   - repos:
       - pingcap/docs-cn
     pull_owners_endpoint: https://prow.tidb.io/ti-community-owners
@@ -949,6 +950,7 @@ ti-community-blunderbuss:
       - junlan-zhang
       - glkappe
       - Joyinqin
+      - qiancai
   - repos:
       - pingcap/docs-dm
     pull_owners_endpoint: https://prow.tidb.io/ti-community-owners
@@ -999,6 +1001,7 @@ ti-community-blunderbuss:
       - junlan-zhang
       - glkappe
       - Joyinqin
+      - qiancai
   - repos:
       - pingcap/docs-tidb-operator
     pull_owners_endpoint: https://prow.tidb.io/ti-community-owners
@@ -1009,6 +1012,7 @@ ti-community-blunderbuss:
       - ti-srebot
       # Inactive reviewers for docs-tidb-operator.
       - lilin90
+      - yikeke
       - breeswish
       - CaitinChen
       - csuzhangxc


### PR DESCRIPTION
Under this config, tichi will auto-cc qiancai in docs-tidb-operator.