### PR TITLE
config: enable tars for tidb dashboard

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -1074,6 +1074,7 @@ ti-community-tars:
       - pingcap/dm
       - pingcap/tidb-tools
       - pingcap/br
+      - pingcap/tidb-dashboard
       - ti-community-infra/test-live
       - ti-community-infra/ti-challenge-bot
       - ti-community-infra/ti-sync-bot

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -637,6 +637,10 @@ external_plugins:
       events:
         - pull_request
         - issue_comment
+    - name: ti-community-tars
+      events:
+        - issue_comment
+        - push
   pingcap/community:
     - name: ti-community-lgtm
       events:


### PR DESCRIPTION
I found that tidb-dashboard was not using tichi to merge PRs, and after checking, I found that tichi could not automatically merge PRs because the repository did not enable the tars plugin to help merge bases. so this PR will enable tars for tidb-dashboard.