### PR TITLE
chore: chaos mesh requires e2e tests before merging PR

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -568,6 +568,7 @@ branch-protection:
                   - "pull (build)"
                   - "pull (test)"
                   - "DCO"
+                  - "chaos-mesh/e2e-test"
                 strict: true
             release-1.1:
               protect: true
@@ -577,6 +578,7 @@ branch-protection:
                   - "pull (build)"
                   - "pull (test)"
                   - "DCO"
+                  - "chaos-mesh/e2e-test"
                 strict: true
             release-1.2:
               protect: true
@@ -586,6 +588,7 @@ branch-protection:
                   - "pull (build)"
                   - "pull (test)"
                   - "DCO"
+                  - "chaos-mesh/e2e-test"
                 strict: true
 
     ti-community-infra:


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

Sometimes e2e tests on Jenkins did not triggered by new commits, so we add this check for the required `chaos-mesh/e2e-test`