### PR TITLE
config: enable cherry-pick-unapproved for tidb

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -839,6 +839,7 @@ tide:
       missingLabels:
         - do-not-merge/hold
         - do-not-merge/work-in-progress
+        - do-not-merge/cherry-pick-not-approved
         - needs-rebase
     - repos:
         - pingcap/dumpling

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -1060,6 +1060,11 @@ ti-community-tars:
       - pingcap/ticdc
       - chaos-mesh/chaos-mesh
     only_when_label: "status/can-merge"
+    exclude_labels:
+      - needs-rebase
+      - do-not-merge/hold
+      - do-not-merge/work-in-progress
+      - do-not-merge/cherry-pick-not-approved
     message: |
       Your PR was out of date, I have automatically updated it for you.
 

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -236,7 +236,7 @@ plugins:
     - lifecycle
     - welcome
     - retitle
-    - cherry_pick_unapproved
+    - cherry-pick-unapproved
   pingcap/docs:
     - welcome
     - assign

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -29,6 +29,16 @@ welcome:
       - chaos-mesh/chaos-mesh
     message_template: "Welcome @{{.AuthorLogin}}! <br><br>It looks like this is your first PR to <a href='https://github.com/{{.Org}}/{{.Repo}}'>{{.Org}}/{{.Repo}}</a> 🎉. <br><br>I'm the bot to help you request reviewers, add labels and more, See [available commands](https://prow.tidb.io/command-help). <br><br>We want to make sure your contribution gets all the attention it needs! <br><br> <br><br>Thank you, and welcome to {{.Org}}/{{.Repo}}. :smiley:"
 
+cherry_pick_unapproved:
+  branchregexp: "^release-(4.0|5.0)"
+  comment: |
+    This cherry pick PR is for a release branch and has not yet been approved by release team.
+    Adding the `do-not-merge/cherry-pick-not-approved` label.
+
+    To merge this cherry pick, it must first be approved (`/lgtm` + `/merge`) by the collaborators.
+
+    **AFTER** it has been approved by collaborators, please ping the release team in a comment to request a cherry pick review.
+
 size:
   s: 10
   m: 30
@@ -226,6 +236,7 @@ plugins:
     - lifecycle
     - welcome
     - retitle
+    - cherry_pick_unapproved
   pingcap/docs:
     - welcome
     - assign


### PR DESCRIPTION
Explicitly adding this label to the PRs of release branch can help us reduce the tars merge base.