### PR TITLE
chore: appending inactive reviewers

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -835,6 +835,36 @@ ti-community-blunderbuss:
       - ti-chi-bot
       - ti-srebot
       # Inactive reviewers for chaos-mesh.
+      - 70data
+      - Andrewmatilde
+      - anotherrachel
+      - caniszczyk
+      - huangxiuyan
+      - Illyrix
+      - jackysp
+      - KivenChen
+      - lucklove
+      - mahjonp
+      - mapleFU
+      - ming535
+      - mrigger
+      - mz921
+      - oraluben
+      - queenypingcap
+      - siddontang
+      - sjwsl
+      - thelinuxfoundation
+      - vincent178
+      - WT-Liu
+      - xuechunL
+      - yikeke
+      - YiniXu9506
+      - Yisaer
+      - you06
+      - zhanghuidinah
+      - zhangysh1995
+      - zhouqiang
+      - zyguan
       # TBD
   - repos:
       - pingcap/docs

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -865,7 +865,6 @@ ti-community-blunderbuss:
       - zhangysh1995
       - zhouqiang
       - zyguan
-      # TBD
   - repos:
       - pingcap/docs
     pull_owners_endpoint: https://prow.tidb.io/ti-community-owners


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

This PR appends a lot of inactive reviewers of Chaos Mesh for avoiding `/auto-cc` assigning;

The list of inactive reviewers contains "oraluben", so I think we could close https://github.com/ti-community-infra/configs/pull/295