### PR TITLE
config: Add labels for chaos-mesh/website

### DIFF
--- a/prow/config/labels.yaml
+++ b/prow/config/labels.yaml
@@ -3120,3 +3120,399 @@ repos:
         prowPlugin: ti-community-label
         isExternalPlugin: true
         addedBy: anyone
+  chaos-mesh/website-zh:
+    labels:
+      - name: good-first-issue
+        color: 9ee169
+        description: "This issue is a good start for first time contributors."
+        target: issues
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: help-wanted
+        color: 128a0c
+        description: "Contributors are welcome to fix this issue."
+        target: issues
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: closed/outdated
+        color: b60205
+        description: Closed because the PR is outdated.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: lifecycle/frozen
+        color: c5def5
+        description: "Issues with this label will not be labeled as \"stale\"."
+        target: issues
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: lifecycle/stale
+        color: cccccc
+        description: This issue has been open for 60 days with no activity.
+        target: issues
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: docs
+        color: 0075ca
+        description: This PR changes user documents.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: missing-translation-status
+        color: ededed
+        description: This PR does not have translation status info.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: priority/P1
+        color: cc0000
+        description: The first priority.
+        target: both
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: priority/P2
+        color: ff7f50
+        description: The second priority.
+        target: both
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: priority/P3
+        color: ff7f50
+        description: The second priority.
+        target: both
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: require-LGT1
+        color: b9f2f7
+        description: This PR needs to get only one LGTM before merging.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: require-LGT2
+        color: 7bf2ee
+        description: This PR needs to get two LGTMs before merging.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: require-LGT3
+        color: 5ee1f2
+        description: This PR needs to get three LGTMs before merging.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: requires-followup
+        color: ebfc80
+        description: This PR requires a follow-up task after being merged.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: status/PTAL
+        color: d876e3
+        description: This PR is ready for reviewing.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: status/TODO
+        color: c2e0c6
+        description: This issue is in a to-do list and will be fixed later.
+        target: issues
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: status/require-change
+        color: ef4845
+        description: Needs the author to address comments.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: suggestion/queeny-test
+        color: 82e5db
+        description: Suggest doing user acceptance testing for documentation.
+        target: both
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: translation/doing
+        color: f2dda9
+        description: This PR’s assignee is translating this PR.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: translation/done
+        color: ffbfd4
+        description: This PR has been translated from English into Chinese and updated to pingcap/docs-cn in a PR.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: translation/from-website-en
+        color: c4e1ff
+        description: This PR is translated from a PR in chaos-mesh/website.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: translation/no-need
+        color: cccccc
+        description: No need to translate this PR.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: translation/welcome
+        color: 3cc460
+        description: Waits for a contributor to translate this PR and create a PR to the pingcap/docs-cn repository.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: type/bug-fix
+        color: d4c5f9
+        description: Fixes typos or wrong format.
+        target: both
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: type/duplicate
+        color: cccccc
+        description: This issue is duplicate with another issue.
+        target: issues
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: type/enhancement
+        color: 84b6eb
+        description: This issue/PR improves documentation usability.
+        target: both
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: type/refactor
+        color: 1044bc
+        description: Reorganizes the documentation structure.
+        target: both
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: type/wontfix
+        color: cccccc
+        description: "This issue won't be fixed."
+        target: issues
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+  chaos-mesh/website:
+    labels:
+      - name: good-first-issue
+        color: 9ee169
+        description: "This issue is a good start for first time contributors."
+        target: issues
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: help-wanted
+        color: 128a0c
+        description: "Contributors are welcome to fix this issue."
+        target: issues
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: closed/outdated
+        color: b60205
+        description: Closed because the PR is outdated.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: lifecycle/frozen
+        color: c5def5
+        description: "Issues with this label will not be labeled as \"stale\"."
+        target: issues
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: lifecycle/stale
+        color: cccccc
+        description: This issue has been open for 60 days with no activity.
+        target: issues
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: docs
+        color: 0075ca
+        description: This PR changes user documents.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: missing-translation-status
+        color: ededed
+        description: This PR does not have translation status info.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: priority/P1
+        color: cc0000
+        description: The first priority.
+        target: both
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: priority/P2
+        color: ff7f50
+        description: The second priority.
+        target: both
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: priority/P3
+        color: ff7f50
+        description: The second priority.
+        target: both
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: require-LGT1
+        color: b9f2f7
+        description: This PR needs to get only one LGTM before merging.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: require-LGT2
+        color: 7bf2ee
+        description: This PR needs to get two LGTMs before merging.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: require-LGT3
+        color: 5ee1f2
+        description: This PR needs to get three LGTMs before merging.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: requires-followup
+        color: ebfc80
+        description: This PR requires a follow-up task after being merged.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: status/PTAL
+        color: d876e3
+        description: This PR is ready for reviewing.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: status/TODO
+        color: c2e0c6
+        description: This issue is in a to-do list and will be fixed later.
+        target: issues
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: status/require-change
+        color: ef4845
+        description: Needs the author to address comments.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: suggestion/queeny-test
+        color: 82e5db
+        description: Suggest doing user acceptance testing for documentation.
+        target: both
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: translation/doing
+        color: f2dda9
+        description: This PR’s assignee is translating this PR.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: translation/done
+        color: ffbfd4
+        description: This PR has been translated from English into Chinese and updated to pingcap/docs-cn in a PR.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: translation/from-website-zh
+        color: c4e1ff
+        description: This PR is translated from a PR in chaos-mesh/website-zh.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: translation/no-need
+        color: cccccc
+        description: No need to translate this PR.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: translation/welcome
+        color: 3cc460
+        description: Waits for a contributor to translate this PR and create a PR to the pingcap/docs-cn repository.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: type/bug-fix
+        color: d4c5f9
+        description: Fixes typos or wrong format.
+        target: both
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: type/duplicate
+        color: cccccc
+        description: This issue is duplicate with another issue.
+        target: issues
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: type/enhancement
+        color: 84b6eb
+        description: This issue/PR improves documentation usability.
+        target: both
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: type/refactor
+        color: 1044bc
+        description: Reorganizes the documentation structure.
+        target: both
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: type/wontfix
+        color: cccccc
+        description: "This issue won't be fixed."
+        target: issues
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone        


### PR DESCRIPTION
This PR adds labels for the following two repos:

chaos-mesh/website
chaos-mesh/website-zh
