### PR TITLE
fix: Do not remind for missing labels on the release branch

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -1218,10 +1218,6 @@ ti-community-cherrypicker:
       - pingcap/ticdc
       - pingcap/dm
       - pingcap/br
-      - pingcap/docs-cn
-      - pingcap/docs
-      - pingcap/docs-dm
-      - pingcap/docs-tidb-operator
     label_prefix: needs-cherry-pick-
     picked_label_prefix: type/cherry-pick-for-
     allow_all: true

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -1247,6 +1247,7 @@ ti-community-cherrypicker:
       - status/LGT3
       - missing-translation-status
       - translation/done
+      - translation/doing
       - translation/from-docs-cn
       - translation/from-docs
       - translation/from-en

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -1231,3 +1231,25 @@ ti-community-cherrypicker:
       - status/LGT1
       - status/LGT2
       - status/LGT3
+  - repos:
+      - pingcap/docs-cn
+      - pingcap/docs
+      - pingcap/docs-dm
+      - pingcap/docs-tidb-operator
+    label_prefix: needs-cherry-pick-
+    picked_label_prefix: type/cherry-pick-for-
+    allow_all: true
+    create_issue_on_conflict: false
+    excludeLabels:
+      - status/can-merge
+      - status/LGT1
+      - status/LGT2
+      - status/LGT3
+      - missing-translation-status
+      - translation/done
+      - translation/from-docs-cn
+      - translation/from-docs
+      - translation/from-en
+      - translation/from-zh
+      - translation/no-need
+      - translation/welcome

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -69,25 +69,25 @@ require_matching_label:
     org: pingcap
     repo: docs
     prs: true
-    regexp: (^translation/)|(type/(.*)-cherry-pick$)
+    regexp: (^translation/)|(type/cherry-pick-for-(.*)$)
     grace_period: 10s
   - missing_label: missing-translation-status
     org: pingcap
     repo: docs-cn
     prs: true
-    regexp: (^translation/)|(type/(.*)-cherry-pick$)
+    regexp: (^translation/)|(type/cherry-pick-for-(.*)$)
     grace_period: 10s
   - missing_label: missing-translation-status
     org: pingcap
     repo: docs-dm
     prs: true
-    regexp: (^translation/)|(type/(.*)-cherry-pick$)
+    regexp: (^translation/)|(type/cherry-pick-for-(.*)$)
     grace_period: 10s
   - missing_label: missing-translation-status
     org: pingcap
     repo: docs-tidb-operator
     prs: true
-    regexp: (^translation/)|(type/(.*)-cherry-pick$)
+    regexp: (^translation/)|(type/cherry-pick-for-(.*)$)
     grace_period: 10s
 
 


### PR DESCRIPTION
We did a migration for labels and forgot to change these regex.