### PR TITLE
config: update the list of auto-assigned reviewers for pd

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -698,27 +698,16 @@ ti-community-blunderbuss:
       - tikv/pd
     pull_owners_endpoint: https://prow.tidb.io/ti-community-owners
     max_request_count: 2
-    exclude_reviewers:
-      # Bots
-      - ti-chi-bot
-      - ti-srebot
-      # Maintainers
-      - siddontang
-      - sunxiaoguang
-      - winkyao
-      - zhangjinpeng1987
-      - lidaobing
-      - fredchenbj
-      - BusyJay
-      # Inactive reviewers
-      - overvenus
-      - Connor1996
-      - qiuyesuifeng
-      - huachaohuang
-      - howardlau1999
-      - xhebox
-      - Luffbee
-      - shafreeck
+    include_reviewers:
+      # Tech Leaders
+      - rleungx
+      # Committers
+      - nolouch
+      - disksing
+      - lhy1024
+      - Yisaer
+      - HunDunDM
+      - JmPotato
   - repos:
       - pingcap/tidb-operator
       - pingcap/tiup


### PR DESCRIPTION
Signed-off-by: HunDunDM <hundundm@gmail.com>

In `ti-community-blunderbuss`, the config of `tikv/pd` uses `include_reviewers` instead of `exclude_reviewers`.

related #311 
