### PR TITLE
config: update the list of auto-assigned reviewers for pingcap/dumpling

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -737,28 +737,10 @@ ti-community-blunderbuss:
       - pingcap/dumpling
     pull_owners_endpoint: https://prow.tidb.io/ti-community-owners
     max_request_count: 2
-    exclude_reviewers:
-      # Bots
-      - ti-chi-bot
-      - ti-srebot
-      # Inactive reviewers for dumpling.
-      - amyangfei
-      - csuzhangxc
-      - glorv
-      - GMHDBJD
-      - IANTHEREAL
-      - leoppro
-      - lonng
-      - WangXiangUSTC
-      - YuJuncens
-      - overvenus
-      - july2993
-      - suzaku
-      - Little-Wallace
-      - holys
-      - liuzix
-      - iamxy
-      - tiancaiamao
+    include_reviewers:
+      - lance6716
+      - lichunzhu
+      - kennytm
   - repos:
       - pingcap/dm
     pull_owners_endpoint: https://prow.tidb.io/ti-community-owners


### PR DESCRIPTION
In ti-community-blunderbuss, the config of pingcap/dumpling uses include_reviewers instead of exclude_reviewers.

part of #311