### PR TITLE
config: update the list of auto-assigned reviewers for ticdc

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -791,24 +791,15 @@ ti-community-blunderbuss:
       - pingcap/ticdc
     pull_owners_endpoint: https://prow.tidb.io/ti-community-owners
     max_request_count: 2
-    exclude_reviewers:
-      # Bots
-      - ti-chi-bot
-      - ti-srebot
-      # Inactive reviewers for ticdc.
-      - csuzhangxc
-      - glorv
-      - GMHDBJD
-      - IANTHEREAL
+    include_reviewers:
+      - overvenus
+      - amyangfei
+      - leoppro
+      - liuzix
       - lonng
-      - WangXiangUSTC
-      - YuJuncens
-      - july2993
-      - suzaku
-      - Little-Wallace
-      - holys
-      - iamxy
-      - tiancaiamao
+      - JinLingChristopher
+      - ben1009
+      - asddongmen
   - repos:
       - pingcap/br
     pull_owners_endpoint: https://prow.tidb.io/ti-community-owners


### PR DESCRIPTION
In `ti-community-blunderbuss`, the config of `tikv/ticdc` uses `include_reviewers` instead of `exclude_reviewers`.

ref #311