### PR TITLE
config: disable release-note for tichi

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -767,7 +767,6 @@ tide:
         - status/can-merge
         - "dco-signoff: yes"
       missingLabels:
-        - do-not-merge/release-note-label-needed
         - do-not-merge/hold
         - do-not-merge/work-in-progress
         - do-not-merge/blocked-paths

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -167,7 +167,6 @@ plugins:
     - milestone
     - milestoneapplier
     - dco
-    - release-note
   ti-community-infra/configs:
     - assign
     - branchcleaner


### PR DESCRIPTION
Because go-releaser collects PR titles for us as changelog, it is useless to enable the plugin. (It was just for testing.)