### PR TITLE
config: update the list of auto-assigned reviewers for BR

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -783,25 +783,16 @@ ti-community-blunderbuss:
       - pingcap/br
     pull_owners_endpoint: https://prow.tidb.io/ti-community-owners
     max_request_count: 2
-    exclude_reviewers:
-      # Bots
-      - ti-chi-bot
-      - ti-srebot
-      # Inactive reviewers for br.
-      - amyangfei
-      - csuzhangxc
-      - GMHDBJD
-      - IANTHEREAL
-      - leoppro
-      - lonng
-      - WangXiangUSTC
-      - YuJuncens
-      - july2993
-      - suzaku
-      - holys
-      - liuzix
-      - iamxy
-      - tiancaiamao
+    include_reviewers:
+      - glorv
+      - gozssky
+      - lichunzhu
+      - kennytm
+      - overvenus
+      - 3pointer
+      - Little-Wallace
+      - zwj-coder
+      - Leavrth
   - repos:
       - chaos-mesh/chaos-mesh
     pull_owners_endpoint: https://prow.tidb.io/ti-community-owners


### PR DESCRIPTION
In ti-community-blunderbuss, the config of pingcap/br uses include_reviewers instead of exclude_reviewers.

ref #311