### PR TITLE
config: update the list of auto-assigned reviewers for tidb-operator

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -710,6 +710,16 @@ ti-community-blunderbuss:
       - JmPotato
   - repos:
       - pingcap/tidb-operator
+    pull_owners_endpoint: https://prow.tidb.io/ti-community-owners
+    max_request_count: 2
+    include_reviewers:
+      - DanielZhangQD
+      - july2993
+      - handlerww
+      - csuzhangxc
+      - liubog2008
+      - better0332
+  - repos:
       - pingcap/tiup
     pull_owners_endpoint: https://prow.tidb.io/ti-community-owners
     max_request_count: 2


### PR DESCRIPTION
In `ti-community-blunderbuss`, the config of `pingcap/tidb-operator` uses `include_reviewers` instead of `exclude_reviewers`.

related #311