### PR TITLE
config: remove lgtm term in cherry_pick_unapproved

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -37,7 +37,7 @@ cherry_pick_unapproved:
     This cherry pick PR is for a release branch and has not yet been approved by release team.
     Adding the `do-not-merge/cherry-pick-not-approved` label.
 
-    To merge this cherry pick, it must first be approved (`/lgtm` + `/merge`) by the collaborators.
+    To merge this cherry pick, it must first be approved by the collaborators.
 
     **AFTER** it has been approved by collaborators, please ping the release team in a comment to request a cherry pick review.
 


### PR DESCRIPTION
Signed-off-by: tison <wander4096@gmail.com>

@Mini256 @hi-rustin I'm unsure the pipeline of cherry-pick. We should remove `/lgtm` term but can we have another suggestive description?