### PR TITLE
fix: revert tars from v1.5.13 to v1.5.12

### DIFF
--- a/prow/cluster/ti_community_tars_deployment.yaml
+++ b/prow/cluster/ti_community_tars_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-tars
-          image: ticommunityinfra/tichi-tars-plugin:v1.5.13
+          image: ticommunityinfra/tichi-tars-plugin:v1.5.12
           imagePullPolicy: Always
           args:
             - --dry-run=false


### PR DESCRIPTION
ref: https://github.com/ti-community-infra/tichi/pull/563

```log
{"client":"github","file":"/home/runner/go/pkg/mod/k8s.io/test-infra@v0.0.0-20210529014624-ff1bf8b1a1bc/prow/github/client.go:761","func":"k8s.io/test-infra/prow/github.(*client).log","level":"info","msg":"UpdatePullRequestBranch(pingcap, dm)","time":"2021-06-03T06:19:41Z"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x8dac3d]

goroutine 74 [running]:
k8s.io/test-infra/prow/github.(*client).UpdatePullRequestBranch(0xc00070fb30, 0xc0007de827, 0x7, 0xc0007de798, 0x2, 0x6a3, 0x0, 0x0, 0x0)
	/home/runner/go/pkg/mod/k8s.io/test-infra@v0.0.0-20210529014624-ff1bf8b1a1bc/prow/github/client.go:4046 +0x39d
github.com/ti-community-infra/tichi/internal/pkg/externalplugins/tars.takeAction(0xc0001fa1c0, 0x7f5d5c1379f8, 0xc00070fb30, 0xc0007de827, 0x7, 0xc0007de798, 0x2, 0x6a3, 0xc0007de900, 0x9, ...)
	/home/runner/work/tichi/tichi/internal/pkg/externalplugins/tars/tars.go:421 +0x1e9
github.com/ti-community-infra/tichi/internal/pkg/externalplugins/tars.handle(0xc0001fa1c0, 0x7f5d5c1379f8, 0xc00070fb30, 0xc0008fb4c0, 0xc0000ad7c0, 0x0, 0x2, 0xc000098300)
	/home/runner/work/tichi/tichi/internal/pkg/externalplugins/tars/tars.go:374 +0x305
github.com/ti-community-infra/tichi/internal/pkg/externalplugins/tars.HandleAll(0xc000512af0, 0x7f5d5c1379f8, 0xc00070fb30, 0xc0001feb00, 0xc0000ad7c0, 0x0, 0x0)
	/home/runner/work/tichi/tichi/internal/pkg/externalplugins/tars/tars.go:331 +0xd2d
main.main.func1()
	/home/runner/work/tichi/tichi/cmd/ticommunitytars/main.go:109 +0x11b
k8s.io/test-infra/prow/interrupts.Tick.func1(0xc000744570, 0xc00073c4c8, 0xc00070fcb0, 0xc00007e380)
	/home/runner/go/pkg/mod/k8s.io/test-infra@v0.0.0-20210529014624-ff1bf8b1a1bc/prow/interrupts/interrupts.go:228 +0x7a
created by k8s.io/test-infra/prow/interrupts.Tick
	/home/runner/go/pkg/mod/k8s.io/test-infra@v0.0.0-20210529014624-ff1bf8b1a1bc/prow/interrupts/interrupts.go:214 +0xbd
```