### PR TITLE
fix: refine ti-community-bot branch protection

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -669,18 +669,6 @@ branch-protection:
                 contexts:
                   - "Semantic Pull Request"
                 strict: false
-        ti-community-bot:
-          branches:
-            master:
-              protect: false
-              required_status_checks:
-                contexts:
-                  - "Semantic Pull Request"
-                  - "codecov/project"
-                  - "pull-ti-community-bot-node10-unit-test"
-                  - "pull-ti-community-bot-node12-unit-test"
-                  - "pull-ti-community-bot-node14-unit-test"
-                strict: false
         ti-challenge-bot:
           branches:
             master:
@@ -874,6 +862,15 @@ tide:
       ti-community-infra:
         skip-unknown-contexts: true
         from-branch-protection: true
+        repos:
+          ti-community-bot:
+            required-contexts:
+              - "Semantic Pull Request"
+              - "codecov/project"
+              - "pull-ti-community-bot-node10-unit-test"
+              - "pull-ti-community-bot-node12-unit-test"
+              - "pull-ti-community-bot-node14-unit-test"
+            skip-unknown-contexts: true
       tikv:
         repos:
           pd:


### PR DESCRIPTION
```log
{"component":"branchprotector","error":"update ti-community-infra: update ti-community-bot: update master from protected=false: get policy: ti-community-infra/ti-community-bot=master defines a policy, which requires protect: true","file":"prow/cmd/branchprotector/protect.go:159","func":"main.main","level":"error","msg":"0","severity":"error","time":"2021-06-15T09:31:29Z"}
{"component":"branchprotector","file":"prow/cmd/branchprotector/protect.go:161","func":"main.main","level":"fatal","msg":"Encountered 1 errors protecting branches","severity":"fatal","time":"2021-06-15T09:31:29Z"}
```