### PR TITLE
config: add the bot configuration for v5.1 branch in two doc repos

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -309,6 +309,14 @@ branch-protection:
                   - "license/cla"
                   - "tide"
                 strict: false
+            release-5.1:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - "ci/circleci: lint"
+                  - "license/cla"
+                  - "tide"
+                strict: false                
         docs-cn:
           branches:
             master:
@@ -359,6 +367,14 @@ branch-protection:
                   - "license/cla"
                   - "tide"
                 strict: false
+            release-5.1:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - "ci/circleci: lint"
+                  - "license/cla"
+                  - "tide"
+                strict: false    
         docs-dm:
           branches:
             master:

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -197,6 +197,8 @@ ti-community-owners:
         default_require_lgtm: 1
       release-5.0:
         default_require_lgtm: 1
+      release-5.1:
+        default_require_lgtm: 1  
   - repos:
       - pingcap/docs-dm
     default_require_lgtm: 2
@@ -402,6 +404,7 @@ ti-community-label:
       - 'needs-cherry-pick-release-3.1'
       - 'needs-cherry-pick-release-4.0'
       - 'needs-cherry-pick-release-5.0'
+      - 'needs-cherry-pick-release-5.1'
       - 'needs-cherry-pick-master'
       - 'question'
       - 'require-LGT1'

--- a/prow/config/labels.yaml
+++ b/prow/config/labels.yaml
@@ -2145,8 +2145,6 @@ repos:
       - name: type/cherry-pick-for-release-5.1
         color: 9ed662
         description: This PR is cherry-picked to release-5.1 from a source PR.
-        previously:
-          - name: type/5.1-cherry-pick
         target: prs
         prowPlugin: ti-community-label
         isExternalPlugin: true

--- a/prow/config/labels.yaml
+++ b/prow/config/labels.yaml
@@ -1502,6 +1502,15 @@ repos:
         prowPlugin: ti-community-label
         isExternalPlugin: true
         addedBy: anyone
+      - name: needs-cherry-pick-release-5.1
+        color: "000000"
+        description: Should cherry pick this PR to release-5.1 branch.
+        previously:
+          - name: needs-cherry-pick-5.1
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
       - name: needs-cherry-pick-master
         color: "000000"
         description: Should cherry pick this PR to master branch.
@@ -1666,6 +1675,15 @@ repos:
         prowPlugin: ti-community-label
         isExternalPlugin: true
         addedBy: anyone
+      - name: type/cherry-pick-for-release-5.1
+        color: 9ad662
+        description: This PR is cherry-picked to release-5.1 from a source PR.
+        previously:
+          - name: type/5.1-cherry-pick
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone  
       - name: type/bug-fix
         color: d4c5f9
         description: Fixes typos or wrong format.
@@ -1944,6 +1962,15 @@ repos:
         prowPlugin: ti-community-label
         isExternalPlugin: true
         addedBy: anyone
+      - name: needs-cherry-pick-release-5.1
+        color: "000000"
+        description: Should cherry pick this PR to release-5.1 branch.
+        previously:
+          - name: needs-cherry-pick-5.1
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone        
       - name: needs-cherry-pick-master
         color: "000000"
         description: Should cherry pick this PR to master branch.
@@ -2115,6 +2142,15 @@ repos:
         prowPlugin: ti-community-label
         isExternalPlugin: true
         addedBy: anyone
+      - name: type/cherry-pick-for-release-5.1
+        color: 9ed662
+        description: This PR is cherry-picked to release-5.1 from a source PR.
+        previously:
+          - name: type/5.1-cherry-pick
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone        
       - name: type/bug-fix
         color: d4c5f9
         description: Fixes typos or wrong format.

--- a/prow/config/labels.yaml
+++ b/prow/config/labels.yaml
@@ -1505,8 +1505,6 @@ repos:
       - name: needs-cherry-pick-release-5.1
         color: "000000"
         description: Should cherry pick this PR to release-5.1 branch.
-        previously:
-          - name: needs-cherry-pick-5.1
         target: prs
         prowPlugin: ti-community-label
         isExternalPlugin: true
@@ -1678,8 +1676,6 @@ repos:
       - name: type/cherry-pick-for-release-5.1
         color: 9ad662
         description: This PR is cherry-picked to release-5.1 from a source PR.
-        previously:
-          - name: type/5.1-cherry-pick
         target: prs
         prowPlugin: ti-community-label
         isExternalPlugin: true
@@ -1965,8 +1961,6 @@ repos:
       - name: needs-cherry-pick-release-5.1
         color: "000000"
         description: Should cherry pick this PR to release-5.1 branch.
-        previously:
-          - name: needs-cherry-pick-5.1
         target: prs
         prowPlugin: ti-community-label
         isExternalPlugin: true


### PR DESCRIPTION
We will create a new branch release-5.1 for the following two doc repos on June 22 so this PR is to add the related bot configurations. 

pingcap/docs-cn
pingcap/docs 