### PR TITLE
config(tikv): remove required contexts on integration tests

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -984,9 +984,6 @@ tide:
             required-contexts:
               - "DCO"
               - "idc-jenkins-ci-tikv/integration-common-test"
-              - "idc-jenkins-ci-tikv/integration-compatibility-test"
-              - "idc-jenkins-ci-tikv/integration-ddl-test"
-              - "idc-jenkins-ci-tikv/integration-copr-test"
               - "idc-jenkins-ci/test"
               - "tide"
             skip-unknown-contexts: true


### PR DESCRIPTION
* tikv: remove required contexts on integration tests. 
* All integration test will be triggered after pr  merged