### PR TITLE
config(pd): remove required contexts on integration tests

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -953,9 +953,6 @@ tide:
           pd:
             required-contexts:
               - "DCO"
-              - "idc-jenkins-ci-pd/integration-common-test"
-              - "idc-jenkins-ci-pd/integration-compatibility-test"
-              - "idc-jenkins-ci-pd/integration-ddl-test"
               - "idc-jenkins-ci/build"
               - "idc-jenkins-ci/test"
             skip-unknown-contexts: true


### PR DESCRIPTION
* pd: remove required contexts on integration tests.
* All integration test will be triggered after pr merged