### PR TITLE
config(tikv): remove context integration-common-test,add context build

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -980,7 +980,7 @@ tide:
             # master / release-3.0 / release-3.1 / release-4.0 / release-5.0 / release-5.1.
             required-contexts:
               - "DCO"
-              - "idc-jenkins-ci-tikv/integration-common-test"
+              - "idc-jenkins-ci-tikv/build"
               - "idc-jenkins-ci/test"
               - "tide"
             skip-unknown-contexts: true


### PR DESCRIPTION
decoupling tikv build binary logic from ci integration-common-test.
* remove required context integration-common-test
* add context build