### PR TITLE
config: Revert "config: auto respond to lgtm (#334)"

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -676,13 +676,6 @@ ti-community-autoresponder:
           It seems you want to merge this PR, I will help you trigger all the tests:
 
           /run-all-tests
-      - regex: "(?i)^/LGTM"
-        message: |
-          Please use GitHub review feature instead of `/lgtm [cancel]` when you want to submit review to the pull request.
-          For how to use GitHub review feature, see also [this document](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews) provided by GitHub.
-
-          For the reason we drop support to the commands, see also [this page](https://book.prow.tidb.io/#/en/plugins/lgtm?id=why-does-lgtm-cancel-take-no-effect-anymore).
-          This reply is being used as a temporary reply during the migration of review process and will be removed on July 1st.
   - repos:
       - tikv/tikv
     auto_responds:
@@ -695,41 +688,6 @@ ti-community-autoresponder:
           You only need to trigger `/merge` once, and if the CI test fails, you just re-trigger the test that failed and the bot will merge the PR for you after the CI passes.
 
           If you have any questions about the PR merge process, please refer to [pr process](https://book.prow.tidb.io/#/en/workflows/pr).
-      - regex: "(?i)^/LGTM"
-        message: |
-          Please use GitHub review feature instead of `/lgtm [cancel]` when you want to submit review to the pull request.
-          For how to use GitHub review feature, see also [this document](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews) provided by GitHub.
-
-          For the reason we drop support to the commands, see also [this page](https://book.prow.tidb.io/#/en/plugins/lgtm?id=why-does-lgtm-cancel-take-no-effect-anymore).
-          This reply is being used as a temporary reply during the migration of review process and will be removed on July 1st.
-  - repos:
-      - tikv/community
-      - pingcap/tidb-dashboard
-      - pingcap/community
-      - pingcap/tidb-operator
-      - pingcap/tiup
-      - pingcap/tidb
-      - pingcap/docs
-      - pingcap/docs-cn
-      - pingcap/docs-dm
-      - pingcap/docs-tidb-operator
-      - pingcap/dumpling
-      - pingcap/dm
-      - pingcap/tidb-tools
-      - pingcap/ticdc
-      - pingcap/br
-      - pingcap/tidb-binlog
-      - chaos-mesh/chaos-mesh
-      - chaos-mesh/website
-      - chaos-mesh/website-zh
-    auto_responds:
-      - regex: "(?i)^/LGTM"
-        message: |
-          Please use GitHub review feature instead of `/lgtm [cancel]` when you want to submit review to the pull request.
-          For how to use GitHub review feature, see also [this document](https://docs.github.com/en/github/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews) provided by GitHub.
-
-          For the reason we drop support to the commands, see also [this page](https://book.prow.tidb.io/#/en/plugins/lgtm?id=why-does-lgtm-cancel-take-no-effect-anymore).
-          This reply is being used as a temporary reply during the migration of review process and will be removed on July 1st.
 
 ti-community-blunderbuss:
   - repos:

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -1040,6 +1040,37 @@ external_plugins:
       events:
         - pull_request
         - issue_comment
+  pingcap/tidb-binlog:
+    - name: ti-community-lgtm
+      events:
+        - pull_request_review
+        - pull_request
+    - name: ti-community-merge
+      events:
+        - issue_comment
+        - pull_request_review_comment
+        - pull_request
+    - name: needs-rebase
+      events:
+        - pull_request
+        - issue_comment
+    - name: ti-community-tars
+      events:
+        - issue_comment
+        - push
+    - name: ti-community-contribution
+      events:
+        - pull_request
+    - name: ti-community-label
+      events:
+        - issue_comment
+    - name: ti-community-label-blocker
+      events:
+        - pull_request
+    - name: ti-community-cherrypicker
+      events:
+        - pull_request
+        - issue_comment
   chaos-mesh/chaos-mesh:
     - name: ti-community-lgtm
       events:

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -580,11 +580,6 @@ external_plugins:
       events:
         - pull_request
         - issue_comment
-    - name: ti-community-autoresponder
-      events:
-        - issue_comment
-        - pull_request_review_comment
-        - pull_request_review
   tikv/pd:
     - name: ti-community-lgtm
       events:
@@ -642,11 +637,6 @@ external_plugins:
       events:
         - issue_comment
         - push
-    - name: ti-community-autoresponder
-      events:
-        - issue_comment
-        - pull_request_review_comment
-        - pull_request_review
   pingcap/community:
     - name: ti-community-lgtm
       events:
@@ -665,11 +655,6 @@ external_plugins:
       events:
         - pull_request
         - issue_comment
-    - name: ti-community-autoresponder
-      events:
-        - issue_comment
-        - pull_request_review_comment
-        - pull_request_review
   pingcap/tidb-operator:
     - name: ti-community-lgtm
       events:
@@ -692,11 +677,6 @@ external_plugins:
       events:
         - issue_comment
         - push
-    - name: ti-community-autoresponder
-      events:
-        - issue_comment
-        - pull_request_review_comment
-        - pull_request_review
   pingcap/tiup:
     - name: ti-community-lgtm
       events:
@@ -722,11 +702,6 @@ external_plugins:
     - name: ti-community-label
       events:
         - issue_comment
-    - name: ti-community-autoresponder
-      events:
-        - issue_comment
-        - pull_request_review_comment
-        - pull_request_review
   tikv/tikv:
     - name: ti-community-lgtm
       events:
@@ -785,11 +760,6 @@ external_plugins:
     - name: ti-community-label-blocker
       events:
         - pull_request
-    - name: ti-community-autoresponder
-      events:
-        - issue_comment
-        - pull_request_review_comment
-        - pull_request_review
   pingcap/docs:
     - name: ti-community-lgtm
       events:
@@ -820,11 +790,6 @@ external_plugins:
       events:
         - pull_request
         - issue_comment
-    - name: ti-community-autoresponder
-      events:
-        - issue_comment
-        - pull_request_review_comment
-        - pull_request_review
   pingcap/docs-cn:
     - name: ti-community-lgtm
       events:
@@ -855,11 +820,6 @@ external_plugins:
       events:
         - pull_request
         - issue_comment
-    - name: ti-community-autoresponder
-      events:
-        - issue_comment
-        - pull_request_review_comment
-        - pull_request_review
   pingcap/docs-dm:
     - name: ti-community-lgtm
       events:
@@ -890,11 +850,6 @@ external_plugins:
       events:
         - pull_request
         - issue_comment
-    - name: ti-community-autoresponder
-      events:
-        - issue_comment
-        - pull_request_review_comment
-        - pull_request_review
   pingcap/docs-tidb-operator:
     - name: ti-community-lgtm
       events:
@@ -925,11 +880,6 @@ external_plugins:
       events:
         - pull_request
         - issue_comment
-    - name: ti-community-autoresponder
-      events:
-        - issue_comment
-        - pull_request_review_comment
-        - pull_request_review
   pingcap/dumpling:
     - name: ti-community-lgtm
       events:
@@ -958,11 +908,6 @@ external_plugins:
       events:
         - pull_request
         - issue_comment
-    - name: ti-community-autoresponder
-      events:
-        - issue_comment
-        - pull_request_review_comment
-        - pull_request_review
   pingcap/dm:
     - name: ti-community-lgtm
       events:
@@ -998,11 +943,6 @@ external_plugins:
       events:
         - pull_request
         - issue_comment
-    - name: ti-community-autoresponder
-      events:
-        - issue_comment
-        - pull_request_review_comment
-        - pull_request_review
   pingcap/tidb-tools:
     - name: ti-community-lgtm
       events:
@@ -1034,11 +974,6 @@ external_plugins:
     - name: ti-community-contribution
       events:
         - pull_request
-    - name: ti-community-autoresponder
-      events:
-        - issue_comment
-        - pull_request_review_comment
-        - pull_request_review
   pingcap/ticdc:
     - name: ti-community-lgtm
       events:
@@ -1074,11 +1009,6 @@ external_plugins:
       events:
         - pull_request
         - issue_comment
-    - name: ti-community-autoresponder
-      events:
-        - issue_comment
-        - pull_request_review_comment
-        - pull_request_review
   pingcap/br:
     - name: ti-community-lgtm
       events:
@@ -1110,47 +1040,6 @@ external_plugins:
       events:
         - pull_request
         - issue_comment
-    - name: ti-community-autoresponder
-      events:
-        - issue_comment
-        - pull_request_review_comment
-        - pull_request_review
-  pingcap/tidb-binlog:
-    - name: ti-community-lgtm
-      events:
-        - pull_request_review
-        - pull_request
-    - name: ti-community-merge
-      events:
-        - issue_comment
-        - pull_request_review_comment
-        - pull_request
-    - name: needs-rebase
-      events:
-        - pull_request
-        - issue_comment
-    - name: ti-community-tars
-      events:
-        - issue_comment
-        - push
-    - name: ti-community-contribution
-      events:
-        - pull_request
-    - name: ti-community-label
-      events:
-        - issue_comment
-    - name: ti-community-label-blocker
-      events:
-        - pull_request
-    - name: ti-community-cherrypicker
-      events:
-        - pull_request
-        - issue_comment
-    - name: ti-community-autoresponder
-      events:
-        - issue_comment
-        - pull_request_review_comment
-        - pull_request_review
   chaos-mesh/chaos-mesh:
     - name: ti-community-lgtm
       events:
@@ -1182,11 +1071,6 @@ external_plugins:
     - name: ti-community-contribution
       events:
         - pull_request
-    - name: ti-community-autoresponder
-      events:
-        - issue_comment
-        - pull_request_review_comment
-        - pull_request_review
   chaos-mesh/website:
     - name: ti-community-lgtm
       events:
@@ -1210,11 +1094,6 @@ external_plugins:
     - name: ti-community-label
       events:
         - issue_comment
-    - name: ti-community-autoresponder
-      events:
-        - issue_comment
-        - pull_request_review_comment
-        - pull_request_review
   chaos-mesh/website-zh:
     - name: ti-community-lgtm
       events:
@@ -1238,9 +1117,3 @@ external_plugins:
     - name: ti-community-label
       events:
         - issue_comment
-    - name: ti-community-autoresponder
-      events:
-        - issue_comment
-        - pull_request_review_comment
-        - pull_request_review
-        


### PR DESCRIPTION
This reverts commit c2c11ec7a6915e6fb79647bb673bf3adaaf6841d.

Remove timely autorespond after july 1st and written before.