### PR TITLE
config: add one type label in two doc repos

### DIFF
--- a/prow/config/labels.md
+++ b/prow/config/labels.md
@@ -241,8 +241,9 @@ larger set of contributors to apply/remove them.
 | <a id="sig/tiup" href="#sig/tiup">`sig/tiup`</a> | Indicates that the Issue or PR belongs to the tiup SIG.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
 | <a id="sig/transaction" href="#sig/transaction">`sig/transaction`</a> | Indicates that the Issue or PR belongs to the transaction SIG.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
 | <a id="sig/web" href="#sig/web">`sig/web`</a> | Indicates that the Issue or PR belongs to the web SIG.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
-| <a id="type/bug-fix" href="#type/bug-fix">`type/bug-fix`</a> | Fixes typos or wrong format.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
-| <a id="type/enhancement" href="#type/enhancement">`type/enhancement`</a> | This issue/PR improves documentation usability.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
+| <a id="type/bug-fix" href="#type/bug-fix">`type/bug-fix`</a> | Fixes typos, wrong format, or other wrong or inaccurate document content.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
+| <a id="type/enhancement" href="#type/enhancement">`type/enhancement`</a> | This issue/PR improves documentation usability or supplements document content.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
+| <a id="type/compatibility-or-feature-change" href="#type/compatibility-or-feature-change">`type/compatibility-or-feature-change`</a> | This PR involves compatibility changes or feature behavior changes.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
 | <a id="type/refactor" href="#type/refactor">`type/refactor`</a> | Reorganizes the documentation structure.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
 | <a id="v4.0" href="#v4.0">`v4.0`</a> | This PR/issue applies to TiDB v4.0.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
 | <a id="v5.0" href="#v5.0">`v5.0`</a> | This PR/issue applies to TiDB v5.0.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
@@ -319,8 +320,9 @@ larger set of contributors to apply/remove them.
 | <a id="sig/transaction" href="#sig/transaction">`sig/transaction`</a> | Indicates that the Issue or PR belongs to the transaction SIG.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
 | <a id="sig/web" href="#sig/web">`sig/web`</a> | Indicates that the Issue or PR belongs to the web SIG.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
 | <a id="suggestion/queeny-test" href="#suggestion/queeny-test">`suggestion/queeny-test`</a> | Suggest doing user acceptance testing for documentation.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
-| <a id="type/bug-fix" href="#type/bug-fix">`type/bug-fix`</a> | Fixes typos or wrong format.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
-| <a id="type/enhancement" href="#type/enhancement">`type/enhancement`</a> | This issue/PR improves documentation usability.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
+| <a id="type/bug-fix" href="#type/bug-fix">`type/bug-fix`</a> | Fixes typos, wrong format, or other wrong or inaccurate document content.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
+| <a id="type/enhancement" href="#type/enhancement">`type/enhancement`</a> | This issue/PR improves documentation usability or supplements document content.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
+| <a id="type/compatibility-or-feature-change" href="#type/compatibility-or-feature-change">`type/compatibility-or-feature-change`</a> | This PR involves compatibility changes or feature behavior changes.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
 | <a id="type/refactor" href="#type/refactor">`type/refactor`</a> | Reorganizes the documentation structure.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
 | <a id="v4.0" href="#v4.0">`v4.0`</a> | This PR/issue applies to TiDB v4.0.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
 | <a id="v5.0" href="#v5.0">`v5.0`</a> | This PR/issue applies to TiDB v5.0| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |

--- a/prow/config/labels.md
+++ b/prow/config/labels.md
@@ -242,8 +242,8 @@ larger set of contributors to apply/remove them.
 | <a id="sig/transaction" href="#sig/transaction">`sig/transaction`</a> | Indicates that the Issue or PR belongs to the transaction SIG.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
 | <a id="sig/web" href="#sig/web">`sig/web`</a> | Indicates that the Issue or PR belongs to the web SIG.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
 | <a id="type/bug-fix" href="#type/bug-fix">`type/bug-fix`</a> | Fixes typos, wrong format, or other wrong or inaccurate document content.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
-| <a id="type/enhancement" href="#type/enhancement">`type/enhancement`</a> | This issue/PR improves documentation usability or supplements document content.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
 | <a id="type/compatibility-or-feature-change" href="#type/compatibility-or-feature-change">`type/compatibility-or-feature-change`</a> | This PR involves compatibility changes or feature behavior changes.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
+| <a id="type/enhancement" href="#type/enhancement">`type/enhancement`</a> | This issue/PR improves documentation usability or supplements document content.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
 | <a id="type/refactor" href="#type/refactor">`type/refactor`</a> | Reorganizes the documentation structure.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
 | <a id="v4.0" href="#v4.0">`v4.0`</a> | This PR/issue applies to TiDB v4.0.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
 | <a id="v5.0" href="#v5.0">`v5.0`</a> | This PR/issue applies to TiDB v5.0.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
@@ -321,8 +321,8 @@ larger set of contributors to apply/remove them.
 | <a id="sig/web" href="#sig/web">`sig/web`</a> | Indicates that the Issue or PR belongs to the web SIG.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
 | <a id="suggestion/queeny-test" href="#suggestion/queeny-test">`suggestion/queeny-test`</a> | Suggest doing user acceptance testing for documentation.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
 | <a id="type/bug-fix" href="#type/bug-fix">`type/bug-fix`</a> | Fixes typos, wrong format, or other wrong or inaccurate document content.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
-| <a id="type/enhancement" href="#type/enhancement">`type/enhancement`</a> | This issue/PR improves documentation usability or supplements document content.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
 | <a id="type/compatibility-or-feature-change" href="#type/compatibility-or-feature-change">`type/compatibility-or-feature-change`</a> | This PR involves compatibility changes or feature behavior changes.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
+| <a id="type/enhancement" href="#type/enhancement">`type/enhancement`</a> | This issue/PR improves documentation usability or supplements document content.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
 | <a id="type/refactor" href="#type/refactor">`type/refactor`</a> | Reorganizes the documentation structure.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
 | <a id="v4.0" href="#v4.0">`v4.0`</a> | This PR/issue applies to TiDB v4.0.| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |
 | <a id="v5.0" href="#v5.0">`v5.0`</a> | This PR/issue applies to TiDB v5.0| anyone |  [ti-community-label](https://book.prow.tidb.io/#/en/plugins) |

--- a/prow/config/labels.yaml
+++ b/prow/config/labels.yaml
@@ -1704,7 +1704,7 @@ repos:
       - name: type/compatibility-or-feature-change
         color: e99695
         description: This PR involves compatibility changes or feature behavior changes.
-        target: prs
+        target: both
         prowPlugin: ti-community-label
         isExternalPlugin: true
         addedBy: anyone
@@ -2174,7 +2174,7 @@ repos:
       - name: type/compatibility-or-feature-change
         color: e99695
         description: This PR involves compatibility changes or feature behavior changes.
-        target: prs
+        target: both
         prowPlugin: ti-community-label
         isExternalPlugin: true
         addedBy: anyone

--- a/prow/config/labels.yaml
+++ b/prow/config/labels.yaml
@@ -1687,6 +1687,20 @@ repos:
         prowPlugin: ti-community-label
         isExternalPlugin: true
         addedBy: anyone
+      - name: type/content-fix
+        color: f9d0c4
+        description: Fixes incorrect document content.
+        target: both
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: type/new-content
+        color: 1d76db
+        description: Adds or supplements new document content.
+        target: both
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
       - name: type/duplicate
         color: cccccc
         description: This issue is duplicate with another issue.
@@ -1698,6 +1712,13 @@ repos:
         color: 84b6eb
         description: This issue/PR improves documentation usability.
         target: both
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: type/compatibility-or-feature-change
+        color: e99695
+        description: This PR involves compatibility changes or feature behavior changes.
+        target: prs
         prowPlugin: ti-community-label
         isExternalPlugin: true
         addedBy: anyone
@@ -2150,6 +2171,20 @@ repos:
         prowPlugin: ti-community-label
         isExternalPlugin: true
         addedBy: anyone
+      - name: type/content-fix
+        color: f9d0c4
+        description: Fixes incorrect document content.
+        target: both
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: type/new-content
+        color: 1d76db
+        description: Adds or supplements new document content.
+        target: both
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
       - name: type/duplicate
         color: cccccc
         description: This issue is duplicate with another issue.
@@ -2161,6 +2196,13 @@ repos:
         color: 84b6eb
         description: This issue/PR improves documentation usability.
         target: both
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: type/compatibility-or-feature-change
+        color: e99695
+        description: This PR involves compatibility changes or feature behavior changes.
+        target: prs
         prowPlugin: ti-community-label
         isExternalPlugin: true
         addedBy: anyone

--- a/prow/config/labels.yaml
+++ b/prow/config/labels.yaml
@@ -1682,7 +1682,7 @@ repos:
         addedBy: anyone
       - name: type/bug-fix
         color: d4c5f9
-        description: Fixes typos, wrong format, or other document content.
+        description: Fixes typos, wrong format, or other wrong or inaccurate document content.
         target: both
         prowPlugin: ti-community-label
         isExternalPlugin: true
@@ -2152,7 +2152,7 @@ repos:
         addedBy: anyone
       - name: type/bug-fix
         color: d4c5f9
-        description: Fixes typos, wrong format, or other document content.
+        description: Fixes typos, wrong format, or other wrong or inaccurate document content.
         target: both
         prowPlugin: ti-community-label
         isExternalPlugin: true

--- a/prow/config/labels.yaml
+++ b/prow/config/labels.yaml
@@ -1696,7 +1696,7 @@ repos:
         addedBy: anyone
       - name: type/enhancement
         color: 84b6eb
-        description: This issue/PR improves documentation usability.
+        description: This issue/PR improves documentation usability or supplements document content.
         target: both
         prowPlugin: ti-community-label
         isExternalPlugin: true
@@ -2561,7 +2561,7 @@ repos:
         addedBy: anyone
       - name: type/enhancement
         color: 84b6eb
-        description: This issue/PR improves documentation usability or supplements document content.
+        description: This issue/PR improves documentation usability.
         target: both
         prowPlugin: ti-community-label
         isExternalPlugin: true

--- a/prow/config/labels.yaml
+++ b/prow/config/labels.yaml
@@ -2166,7 +2166,7 @@ repos:
         addedBy: anyone
       - name: type/enhancement
         color: 84b6eb
-        description: This issue/PR improves documentation usability.
+        description: This issue/PR improves documentation usability or supplements document content.
         target: both
         prowPlugin: ti-community-label
         isExternalPlugin: true
@@ -2561,7 +2561,7 @@ repos:
         addedBy: anyone
       - name: type/enhancement
         color: 84b6eb
-        description: This issue/PR improves documentation usability.
+        description: This issue/PR improves documentation usability or supplements document content.
         target: both
         prowPlugin: ti-community-label
         isExternalPlugin: true

--- a/prow/config/labels.yaml
+++ b/prow/config/labels.yaml
@@ -1682,21 +1682,7 @@ repos:
         addedBy: anyone
       - name: type/bug-fix
         color: d4c5f9
-        description: Fixes typos or wrong format.
-        target: both
-        prowPlugin: ti-community-label
-        isExternalPlugin: true
-        addedBy: anyone
-      - name: type/content-fix
-        color: f9d0c4
-        description: Fixes incorrect document content.
-        target: both
-        prowPlugin: ti-community-label
-        isExternalPlugin: true
-        addedBy: anyone
-      - name: type/new-content
-        color: 1d76db
-        description: Adds or supplements new document content.
+        description: Fixes typos, wrong format, or other document content.
         target: both
         prowPlugin: ti-community-label
         isExternalPlugin: true
@@ -2166,21 +2152,7 @@ repos:
         addedBy: anyone
       - name: type/bug-fix
         color: d4c5f9
-        description: Fixes typos or wrong format.
-        target: both
-        prowPlugin: ti-community-label
-        isExternalPlugin: true
-        addedBy: anyone
-      - name: type/content-fix
-        color: f9d0c4
-        description: Fixes incorrect document content.
-        target: both
-        prowPlugin: ti-community-label
-        isExternalPlugin: true
-        addedBy: anyone
-      - name: type/new-content
-        color: 1d76db
-        description: Adds or supplements new document content.
+        description: Fixes typos, wrong format, or other document content.
         target: both
         prowPlugin: ti-community-label
         isExternalPlugin: true


### PR DESCRIPTION
This PR adds the `type/compatibility-or-feature-change` label and modifies the description of `type/bug-fix` for docs-cn and docs repositories.
