### PR TITLE
config(ticdc): remove some required_status_checks in release-4.0

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -537,10 +537,6 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
-                  - 'Docker Build'
-                  - 'Make Check & Build (ubuntu-latest)'
-                  - 'Make Check & Build (macos-latest)'
-                  - 'Lint'
                   - 'idc-jenkins-ci-ticdc/integration-test'
                   - 'idc-jenkins-ci-ticdc/kafka-integration-test'
                   - 'idc-jenkins-ci-ticdc/unit-test'


### PR DESCRIPTION
Ref: https://github.com/pingcap/ticdc/pull/2409, `Lint` check has been removed.

Other checks are kept the same required_status_checks with release-5.0/release-5.1 and master branch in release-4.0.

