### PR TITLE
config(ticdc): ignore the can-merge and ptal labels

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -1045,6 +1045,9 @@ ti-community-cherrypicker:
     picked_label_prefix: type/cherry-pick-for-
     allow_all: true
     create_issue_on_conflict: false
+    excludeLabels:
+      - status/can-merge
+      - status/ptal
   - repos:
       - pingcap/docs-cn
       - pingcap/docs


### PR DESCRIPTION
Because when using `/merge` command the bot will record the current commit to keep track of whether there are new commits, and then cancel merge.
Since cherry-pick's PR does not record the commit, the label disappears automatically when the bot merges base.
So it is currently not possible to copy the can-merge label directly.

cc: @amyangfei  