### PR TITLE
config: add cherry-pick-approved trusted users

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -970,9 +970,33 @@ ti-community-label-blocker:
   - repos:
       - pingcap/dumpling
       - pingcap/dm
-      - pingcap/tidb-tools
       - pingcap/ticdc
       - pingcap/br
+    block_labels:
+      - regex: "^status/LGT[\\d]+$"
+        actions:
+          - labeled
+          - unlabeled
+        trusted_users:
+          - ti-chi-bot
+      - regex: "^status/can-merge$"
+        actions:
+          - labeled
+          - unlabeled
+        trusted_users:
+          - ti-chi-bot
+      - regex: "^cherry-pick-approved$"
+        actions:
+          - labeled
+          - unlabeled
+        trusted_teams:
+          - qa-release-merge
+        trusted_users:
+          - ti-chi-bot
+          - lonng
+          - nongfushanquan
+  - repos:
+      - pingcap/tidb-tools
       - pingcap/tidb-binlog
     block_labels:
       - regex: "^status/LGT[\\d]+$"


### PR DESCRIPTION
Allow @nongfushanquan add  cherry-pick-approved label on PR of `pingcap/dumpling` / `pingcap/dm` / `pingcap/ticdc` / `pingcap/br` repos.