### PR TITLE
config: add exclude labels for tars

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -901,7 +901,9 @@ ti-community-tars:
     exclude_labels:
       - needs-rebase
       - do-not-merge/hold
+      - do-not-merge/blocked-paths
       - do-not-merge/work-in-progress
+      - do-not-merge/release-note-label-needed
       - do-not-merge/cherry-pick-not-approved
     message: |
       Your PR was out of date, I have automatically updated it for you.
@@ -924,7 +926,9 @@ ti-community-tars:
     exclude_labels:
       - needs-rebase
       - do-not-merge/hold
+      - do-not-merge/blocked-paths
       - do-not-merge/work-in-progress
+      - do-not-merge/release-note-label-needed
       - do-not-merge/cherry-pick-not-approved
     message: |
       Your PR was out of date, I have automatically updated it for you.


### PR DESCRIPTION
Fix the problem of inconsistency between tars and tide, which will cause tars to perform redundant merge master operations and fail to complete the merge, this wastes a lot of CI resources.