### PR TITLE
config: enable milestoneapplier for tics

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -345,6 +345,7 @@ plugins:
     - size
     - lifecycle
     - release-note
+    - milestoneapplier
   chaos-mesh/chaos-mesh:
     - welcome
     - assign


### PR DESCRIPTION
```
The milestoneapplier plugin automatically applies the configured milestone for the base branch after a PR is merged. If a PR targets a non-default branch, it also adds the milestone when the PR is opened.
```
I think it is a useful plugin that we can know which PRs are merged in a specified milestone.