### PR TITLE
feat: enable cherry-pick-unapproved for tics

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -665,11 +665,12 @@ ti-community-label:
       - 'question'
       - 'wontfix'
       - 'make-local-great-again'
-      - 'needs-cherry-pick-3.1'
-      - 'needs-cherry-pick-4.0'
-      - 'needs-cherry-pick-5.0-rc'
-      - 'needs-cherry-pick-5.0'
-      - 'needs-cherry-pick-5.1'
+      - 'needs-cherry-pick-release-3.1'
+      - 'needs-cherry-pick-release-4.0'
+      - 'needs-cherry-pick-release-5.0-rc'
+      - 'needs-cherry-pick-release-5.0'
+      - 'needs-cherry-pick-release-5.1'
+      - 'needs-cherry-pick-release-5.2'
       - 'needs-rebase'
     exclude_labels:
       - status/can-merge

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -345,6 +345,7 @@ plugins:
     - size
     - lifecycle
     - release-note
+    - cherry-pick-unapproved
   chaos-mesh/chaos-mesh:
     - welcome
     - assign


### PR DESCRIPTION
- The `cherry-pick-unapproved` plugin will add the `do-not-merge/cherry-pick-not-approved` label to the PR submitted to the release branch. 
- The robot will not perform merge base operations and merge pull request operations on PRs with the label of `do-not-merge/cherry-pick-not-approved`
- Only release team members can add the `cherry-pick-approved` label and cancel the `do-not-merge/cherry-pick-not-approved` label.
