### PR TITLE
feat: add release-5.2 config for some repo

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -68,6 +68,15 @@ branch-protection:
                   - "idc-jenkins-ci/test"
                   - "idc-jenkins-ci/build"
                 strict: true
+            release-5.2:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - "DCO"
+                  - "statics"
+                  - "idc-jenkins-ci/test"
+                  - "idc-jenkins-ci/build"
+                strict: true
         tikv:
           branches:
             master:
@@ -123,6 +132,17 @@ branch-protection:
                 users:
                   - ti-chi-bot
             release-5.1:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - "DCO"
+                  - "idc-jenkins-ci/test"
+                  - "tide"
+                strict: true
+              restrictions:
+                users:
+                  - ti-chi-bot
+            release-5.2:
               protect: true
               required_status_checks:
                 contexts:
@@ -265,6 +285,19 @@ branch-protection:
                 users:
                   - ti-chi-bot
             release-5.1:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - "idc-jenkins-ci-tidb/build"
+                  - "idc-jenkins-ci-tidb/check_dev"
+                  - "idc-jenkins-ci-tidb/check_dev_2"
+                  - "license/cla"
+                  - "tide"
+                strict: true
+              restrictions:
+                users:
+                  - ti-chi-bot
+            release-5.2:
               protect: true
               required_status_checks:
                 contexts:
@@ -489,6 +522,14 @@ branch-protection:
                   - "integration-test"
                   - "license/cla"
                 strict: false
+            release-5.2:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - "unit-test"
+                  - "integration-test"
+                  - "license/cla"
+                strict: false
         dm:
           branches:
             master:
@@ -526,6 +567,12 @@ branch-protection:
                   - 'idc-jenkins-ci-tidb-tools/unit-test'
                 strict: true
             release-5.1:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - 'idc-jenkins-ci-tidb-tools/unit-test'
+                strict: true
+            release-5.2:
               protect: true
               required_status_checks:
                 contexts:
@@ -625,6 +672,16 @@ branch-protection:
                   - 'idc-jenkins-ci-tidb-binlog/check_release_note'
                   - 'idc-jenkins-ci-tidb-binlog/unit-test'
                 strict: true
+            release-5.2:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - 'idc-jenkins-ci-binlog/build'
+                  - 'idc-jenkins-ci-binlog/check'
+                  - 'idc-jenkins-ci-tidb-binlog/integration-test'
+                  - 'idc-jenkins-ci-tidb-binlog/check_release_note'
+                  - 'idc-jenkins-ci-tidb-binlog/unit-test'
+                strict: true
         br:
           branches:
             master:
@@ -687,6 +744,13 @@ branch-protection:
                   - 'license/cla'
                 strict: true
             release-5.1:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - 'ci/circleci: build-ut'
+                  - 'license/cla'
+                strict: true
+            release-5.2:
               protect: true
               required_status_checks:
                 contexts:
@@ -1076,9 +1140,13 @@ tide:
                 required-contexts:
                   - "statics"
                 skip-unknown-contexts: true
+              release-5.2:
+                required-contexts:
+                  - "statics"
+                skip-unknown-contexts: true
           tikv:
             # Notice: The following configuration takes effect for these branches:
-            # master / release-3.0 / release-3.1 / release-4.0 / release-5.0 / release-5.1.
+            # master / release-3.0 / release-3.1 / release-4.0 / release-5.0 / release-5.1 / release-5.2.
             required-contexts:
               - "DCO"
               - "idc-jenkins-ci-tikv/build"
@@ -1133,7 +1201,7 @@ tide:
             from-branch-protection: true
           tidb:
             # Notice: The following configuration takes effect for these branches:
-            # master / release-3.0 / release-4.0 / release-5.0/ release-5.1.
+            # master / release-3.0 / release-4.0 / release-5.0 / release-5.1 / release-5.2.
             required-contexts:
               - "idc-jenkins-ci-tidb/build"
               - "idc-jenkins-ci-tidb/check_dev"

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -145,6 +145,9 @@ ti-community-owners:
       release-5.1:
         trusted_teams:
           - qa-release-merge
+      release-5.2:
+        trusted_teams:
+          - qa-release-merge
   - repos:
       - tikv/community
       - pingcap/community
@@ -297,6 +300,7 @@ ti-community-label:
       - 'needs-cherry-pick-release-4.0'
       - 'needs-cherry-pick-release-5.0'
       - 'needs-cherry-pick-release-5.1'
+      - 'needs-cherry-pick-release-5.2'
       - 'release-note'
       - 'require-LGT1'
       - 'wontfix'
@@ -324,6 +328,7 @@ ti-community-label:
       - 'needs-cherry-pick-4.0'
       - 'needs-cherry-pick-5.0'
       - 'needs-cherry-pick-5.1'
+      - 'needs-cherry-pick-5.2'
       - 'wontfix'
       - 'do-not-merge/cherry-pick-not-approved'
     exclude_labels:
@@ -358,6 +363,7 @@ ti-community-label:
       - 'needs-cherry-pick-4.0'
       - 'needs-cherry-pick-5.0'
       - 'needs-cherry-pick-5.1'
+      - 'needs-cherry-pick-5.2'
       - 'proposal'
       - 'release-note'
       - 'require-LGT3'
@@ -393,6 +399,7 @@ ti-community-label:
       - 'needs-cherry-pick-release-4.0'
       - 'needs-cherry-pick-release-5.0'
       - 'needs-cherry-pick-release-5.1'
+      - 'needs-cherry-pick-release-5.2'
       - 'needs-cherry-pick-master'
       - 'question'
       - 'require-LGT1'
@@ -560,6 +567,7 @@ ti-community-label:
       - 'needs-cherry-pick-release-4.0'
       - 'needs-cherry-pick-release-5.0'
       - 'needs-cherry-pick-release-5.1'
+      - 'needs-cherry-pick-release-5.2'
       - 'question'
       - 'release-blocker'
       - 'wontfix'
@@ -599,11 +607,6 @@ ti-community-label:
       - status
       - type
     additional_labels:
-      - 'already-cherry-pick-2.1'
-      - 'already-cherry-pick-3.0'
-      - 'already-cherry-pick-3.1'
-      - 'already-cherry-pick-4.0'
-      - 'already-cherry-pick-5.0'
       - 'contribution'
       - 'duplicate'
       - 'feature-request'
@@ -617,6 +620,7 @@ ti-community-label:
       - 'needs-cherry-pick-release-4.0'
       - 'needs-cherry-pick-release-5.0'
       - 'needs-cherry-pick-release-5.1'
+      - 'needs-cherry-pick-release-5.2'
       - 'p0'
       - 'p1'
       - 'p2'
@@ -638,12 +642,13 @@ ti-community-label:
       - 'for new contributors'
       - 'help wanted'
       - 'hptc'
-      - 'needs-cherry-pick-2.1'
-      - 'needs-cherry-pick-3.0'
-      - 'needs-cherry-pick-3.1'
-      - 'needs-cherry-pick-4.0'
-      - 'needs-cherry-pick-5.0'
-      - 'needs-cherry-pick-5.1'
+      - 'needs-cherry-pick-release-2.1'
+      - 'needs-cherry-pick-release-3.0'
+      - 'needs-cherry-pick-release-3.1'
+      - 'needs-cherry-pick-release-4.0'
+      - 'needs-cherry-pick-release-5.0'
+      - 'needs-cherry-pick-release-5.1'
+      - 'needs-cherry-pick-release-5.2'
       - 'needs-rebase'
       - 'question'
     exclude_labels:
@@ -699,6 +704,7 @@ ti-community-label:
       - 'needs-cherry-pick-1.0'
       - 'needs-cherry-pick-1.1'
       - 'needs-cherry-pick-1.2'
+      - 'needs-cherry-pick-2.0'
       - 'website'
       - 'require-LGT3'
     exclude_labels:


### PR DESCRIPTION
Enable release-5.2 config for the following repo:

- pingcap/tidb
- pingcap/dumpling
- pingcap/tidb-tools
- pingcap/tidb-binlog
- pingcap/parser
- tikv/pd
- tikv/tikv

The following repo has not yet checkout the release-5.2 branch:

- pingcap/docs
- pingcap/docs-cn
- pingcap/br
