### PR TITLE
build: bump ti plugins to v1.8.0

### DIFF
--- a/prow/cluster/ti_community_autoresponder_deployment.yaml
+++ b/prow/cluster/ti_community_autoresponder_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-autoresponder
-          image: ticommunityinfra/tichi-autoresponder-plugin:v1.7.2
+          image: ticommunityinfra/tichi-autoresponder-plugin:v1.8.0
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_blunderbuss_deployment.yaml
+++ b/prow/cluster/ti_community_blunderbuss_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-blunderbuss
-          image: ticommunityinfra/tichi-blunderbuss-plugin:v1.7.2
+          image: ticommunityinfra/tichi-blunderbuss-plugin:v1.8.0
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_cherrypicker_deployment.yaml
+++ b/prow/cluster/ti_community_cherrypicker_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-cherrypicker
-          image: ticommunityinfra/tichi-cherrypicker-plugin:v1.7.2
+          image: ticommunityinfra/tichi-cherrypicker-plugin:v1.8.0
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_contribution_deployment.yaml
+++ b/prow/cluster/ti_community_contribution_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-contribution
-          image: ticommunityinfra/tichi-contribution-plugin:v1.7.2
+          image: ticommunityinfra/tichi-contribution-plugin:v1.8.0
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_label_blocker_deployment.yaml
+++ b/prow/cluster/ti_community_label_blocker_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-label-blocker
-          image: ticommunityinfra/tichi-label-blocker-plugin:v1.7.2
+          image: ticommunityinfra/tichi-label-blocker-plugin:v1.8.0
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_label_deployment.yaml
+++ b/prow/cluster/ti_community_label_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-label
-          image: ticommunityinfra/tichi-label-plugin:v1.7.2
+          image: ticommunityinfra/tichi-label-plugin:v1.8.0
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_lgtm_deployment.yaml
+++ b/prow/cluster/ti_community_lgtm_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-lgtm
-          image: ticommunityinfra/tichi-lgtm-plugin:v1.7.2
+          image: ticommunityinfra/tichi-lgtm-plugin:v1.8.0
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_merge_deployment.yaml
+++ b/prow/cluster/ti_community_merge_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-merge
-          image: ticommunityinfra/tichi-merge-plugin:v1.7.2
+          image: ticommunityinfra/tichi-merge-plugin:v1.8.0
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_owners_deployment.yaml
+++ b/prow/cluster/ti_community_owners_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-owners
-          image: ticommunityinfra/tichi-owners-plugin:v1.7.2
+          image: ticommunityinfra/tichi-owners-plugin:v1.8.0
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_tars_deployment.yaml
+++ b/prow/cluster/ti_community_tars_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-tars
-          image: ticommunityinfra/tichi-tars-plugin:v1.7.2
+          image: ticommunityinfra/tichi-tars-plugin:v1.8.0
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/tichi_web_deployment.yaml
+++ b/prow/cluster/tichi_web_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: tichi-web
-          image: ticommunityinfra/tichi-web:v1.7.2
+          image: ticommunityinfra/tichi-web:v1.8.0
           imagePullPolicy: Always
           ports:
             - name: http

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -97,13 +97,13 @@ ti-community-owners:
       - pingcap/tidb-dashboard
     default_sig_name: diagnosis
     default_require_lgtm: 1
-    trusted_teams:
+    committer_teams:
       - maintainers
     sig_endpoint: https://bots.tidb.io/ti-community-bot
   - repos:
       - pingcap/tidb-operator
     default_sig_name: k8s
-    trusted_teams:
+    committer_teams:
       - maintainers
     sig_endpoint: https://bots.tidb.io/ti-community-bot
     require_lgtm_label_prefix: require-LGT
@@ -115,7 +115,7 @@ ti-community-owners:
   - repos:
       - pingcap/tiup
     default_sig_name: tiup
-    trusted_teams:
+    committer_teams:
       - maintainers
     sig_endpoint: https://bots.tidb.io/ti-community-bot
     default_require_lgtm: 1
@@ -127,28 +127,28 @@ ti-community-owners:
     require_lgtm_label_prefix: require-LGT
   - repos:
       - pingcap/tidb
-    trusted_teams:
+    committer_teams:
       - tidb-maintainer
     sig_endpoint: https://bots.tidb.io/ti-community-bot
     require_lgtm_label_prefix: require-LGT
     branches:
       release-2.1:
-        trusted_teams:
+        committer_teams:
           - qa-release-merge
       release-3.0:
-        trusted_teams:
+        committer_teams:
           - qa-release-merge
       release-4.0:
-        trusted_teams:
+        committer_teams:
           - qa-release-merge
       release-5.0:
-        trusted_teams:
+        committer_teams:
           - qa-release-merge
       release-5.1:
-        trusted_teams:
+        committer_teams:
           - qa-release-merge
       release-5.2:
-        trusted_teams:
+        committer_teams:
           - qa-release-merge
   - repos:
       - tikv/community

--- a/prow/jobs/ti-community-infra/configs/configs-presubmits.yaml
+++ b/prow/jobs/ti-community-infra/configs/configs-presubmits.yaml
@@ -21,7 +21,7 @@ presubmits:
         - ^main$
       spec:
         containers:
-          - image: ticommunityinfra/tichi-check-external-plugin-config:v1.7.2
+          - image: ticommunityinfra/tichi-check-external-plugin-config:v1.8.0
             command:
               - check-external-plugin-config
             args:


### PR DESCRIPTION
part of   https://github.com/pingcap/community/issues/520

add teams configs on:
- https://github.com/ti-community-infra/configs/pull/414

owners config on test-dev:
- https://github.com/ti-community-infra/tichi/blob/e1a22dde11f41b5062801cf05388f225761e26fe/configs/prow-dev/config/external_plugins_config.yaml#L16

test on: 
- https://github.com/ti-community-infra/test-dev/pull/423 (use_gtihub_permission)
- https://github.com/ti-community-infra/test-dev/pull/422 (auth base on sig)

owners link:
- https://prow-dev.tidb.io/tichi/repos/ti-community-infra/test-dev/pulls/423/owners
- https://prow-dev.tidb.io/tichi/repos/ti-community-infra/test-dev/pulls/422/owners
