### PR TITLE
config: Revert "build: bump ti plugins version from v1.8.1 to v1.8.2 (#423)"

### DIFF
--- a/prow/cluster/ti_community_autoresponder_deployment.yaml
+++ b/prow/cluster/ti_community_autoresponder_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-autoresponder
-          image: ticommunityinfra/tichi-autoresponder-plugin:v1.8.2
+          image: ticommunityinfra/tichi-autoresponder-plugin:v1.8.1
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_blunderbuss_deployment.yaml
+++ b/prow/cluster/ti_community_blunderbuss_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-blunderbuss
-          image: ticommunityinfra/tichi-blunderbuss-plugin:v1.8.2
+          image: ticommunityinfra/tichi-blunderbuss-plugin:v1.8.1
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_cherrypicker_deployment.yaml
+++ b/prow/cluster/ti_community_cherrypicker_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-cherrypicker
-          image: ticommunityinfra/tichi-cherrypicker-plugin:v1.8.2
+          image: ticommunityinfra/tichi-cherrypicker-plugin:v1.8.1
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_contribution_deployment.yaml
+++ b/prow/cluster/ti_community_contribution_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-contribution
-          image: ticommunityinfra/tichi-contribution-plugin:v1.8.2
+          image: ticommunityinfra/tichi-contribution-plugin:v1.8.1
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_label_blocker_deployment.yaml
+++ b/prow/cluster/ti_community_label_blocker_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-label-blocker
-          image: ticommunityinfra/tichi-label-blocker-plugin:v1.8.2
+          image: ticommunityinfra/tichi-label-blocker-plugin:v1.8.1
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_label_deployment.yaml
+++ b/prow/cluster/ti_community_label_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-label
-          image: ticommunityinfra/tichi-label-plugin:v1.8.2
+          image: ticommunityinfra/tichi-label-plugin:v1.8.1
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_lgtm_deployment.yaml
+++ b/prow/cluster/ti_community_lgtm_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-lgtm
-          image: ticommunityinfra/tichi-lgtm-plugin:v1.8.2
+          image: ticommunityinfra/tichi-lgtm-plugin:v1.8.1
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_merge_deployment.yaml
+++ b/prow/cluster/ti_community_merge_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-merge
-          image: ticommunityinfra/tichi-merge-plugin:v1.8.2
+          image: ticommunityinfra/tichi-merge-plugin:v1.8.1
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_owners_deployment.yaml
+++ b/prow/cluster/ti_community_owners_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-owners
-          image: ticommunityinfra/tichi-owners-plugin:v1.8.2
+          image: ticommunityinfra/tichi-owners-plugin:v1.8.1
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/ti_community_tars_deployment.yaml
+++ b/prow/cluster/ti_community_tars_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: ti-community-tars
-          image: ticommunityinfra/tichi-tars-plugin:v1.8.2
+          image: ticommunityinfra/tichi-tars-plugin:v1.8.1
           imagePullPolicy: Always
           args:
             - --dry-run=false

--- a/prow/cluster/tichi_web_deployment.yaml
+++ b/prow/cluster/tichi_web_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
         - name: tichi-web
-          image: ticommunityinfra/tichi-web:v1.8.2
+          image: ticommunityinfra/tichi-web:v1.8.1
           imagePullPolicy: Always
           ports:
             - name: http

--- a/prow/jobs/ti-community-infra/configs/configs-presubmits.yaml
+++ b/prow/jobs/ti-community-infra/configs/configs-presubmits.yaml
@@ -21,7 +21,7 @@ presubmits:
         - ^main$
       spec:
         containers:
-          - image: ticommunityinfra/tichi-check-external-plugin-config:v1.8.2
+          - image: ticommunityinfra/tichi-check-external-plugin-config:v1.8.1
             command:
               - check-external-plugin-config
             args:


### PR DESCRIPTION
This reverts commit df1ffa7dc8829812296c90203fee38933b4e7a2f.