### PR TITLE
config(tidb): enable require code owner reviews

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -224,6 +224,9 @@ branch-protection:
           branches:
             master:
               protect: true
+              required_pull_request_reviews:
+                require_code_owner_reviews: true
+                required_approving_review_count: 2
               required_status_checks:
                 contexts:
                   - "idc-jenkins-ci-tidb/build"
@@ -237,6 +240,9 @@ branch-protection:
                 strict: true
             release-2.1:
               protect: true
+              required_pull_request_reviews:
+                require_code_owner_reviews: true
+                required_approving_review_count: 2
               required_status_checks:
                 contexts:
                   - "idc-jenkins-ci-tidb/build"
@@ -252,6 +258,9 @@ branch-protection:
                   - ti-chi-bot
             release-3.0:
               protect: true
+              required_pull_request_reviews:
+                require_code_owner_reviews: true
+                required_approving_review_count: 2
               required_status_checks:
                 contexts:
                   - "idc-jenkins-ci-tidb/build"
@@ -267,6 +276,9 @@ branch-protection:
                   - ti-chi-bot
             release-4.0:
               protect: true
+              required_pull_request_reviews:
+                require_code_owner_reviews: true
+                required_approving_review_count: 2
               required_status_checks:
                 contexts:
                   - "idc-jenkins-ci-tidb/build"
@@ -282,6 +294,9 @@ branch-protection:
                   - ti-chi-bot
             release-5.0:
               protect: true
+              required_pull_request_reviews:
+                require_code_owner_reviews: true
+                required_approving_review_count: 2
               required_status_checks:
                 contexts:
                   - "idc-jenkins-ci-tidb/build"
@@ -297,6 +312,9 @@ branch-protection:
                   - ti-chi-bot
             release-5.1:
               protect: true
+              required_pull_request_reviews:
+                require_code_owner_reviews: true
+                required_approving_review_count: 2
               required_status_checks:
                 contexts:
                   - "idc-jenkins-ci-tidb/build"
@@ -312,6 +330,9 @@ branch-protection:
                   - ti-chi-bot
             release-5.2:
               protect: true
+              required_pull_request_reviews:
+                require_code_owner_reviews: true
+                required_approving_review_count: 2
               required_status_checks:
                 contexts:
                   - "idc-jenkins-ci-tidb/build"

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -226,7 +226,7 @@ branch-protection:
               protect: true
               required_pull_request_reviews:
                 require_code_owner_reviews: true
-                required_approving_review_count: 2
+                required_approving_review_count: 1
               required_status_checks:
                 contexts:
                   - "idc-jenkins-ci-tidb/build"
@@ -242,7 +242,7 @@ branch-protection:
               protect: true
               required_pull_request_reviews:
                 require_code_owner_reviews: true
-                required_approving_review_count: 2
+                required_approving_review_count: 1
               required_status_checks:
                 contexts:
                   - "idc-jenkins-ci-tidb/build"
@@ -260,7 +260,7 @@ branch-protection:
               protect: true
               required_pull_request_reviews:
                 require_code_owner_reviews: true
-                required_approving_review_count: 2
+                required_approving_review_count: 1
               required_status_checks:
                 contexts:
                   - "idc-jenkins-ci-tidb/build"
@@ -278,7 +278,7 @@ branch-protection:
               protect: true
               required_pull_request_reviews:
                 require_code_owner_reviews: true
-                required_approving_review_count: 2
+                required_approving_review_count: 1
               required_status_checks:
                 contexts:
                   - "idc-jenkins-ci-tidb/build"
@@ -296,7 +296,7 @@ branch-protection:
               protect: true
               required_pull_request_reviews:
                 require_code_owner_reviews: true
-                required_approving_review_count: 2
+                required_approving_review_count: 1
               required_status_checks:
                 contexts:
                   - "idc-jenkins-ci-tidb/build"
@@ -314,7 +314,7 @@ branch-protection:
               protect: true
               required_pull_request_reviews:
                 require_code_owner_reviews: true
-                required_approving_review_count: 2
+                required_approving_review_count: 1
               required_status_checks:
                 contexts:
                   - "idc-jenkins-ci-tidb/build"
@@ -332,7 +332,7 @@ branch-protection:
               protect: true
               required_pull_request_reviews:
                 require_code_owner_reviews: true
-                required_approving_review_count: 2
+                required_approving_review_count: 1
               required_status_checks:
                 contexts:
                   - "idc-jenkins-ci-tidb/build"


### PR DESCRIPTION
#### Proposal

https://internals.tidb.io/t/topic/374/15?u=mini256

#### Related PR

https://github.com/pingcap/tidb/pull/28249

#### How it works

**Notice**: When this PR is merged, the robot will automatically synchronize the configuration to the branch protection configuration of the GitHub repository.

![image](https://user-images.githubusercontent.com/5086433/134446173-5ac78947-d797-4af5-abf7-26dca6fa1817.png)

We enable the CODEOWNERS to implement our config review mechanism by turning on the `require_code_owner_reviews` option.

But GitHub will require us to enable the `required_approving_review_count` option at the same time, and the minimum value of this option is 1. 

It will require our PR to pass through at least one reviewer with **write permission** before it can be merged. However, our *team reviewer* only has read permission in the repository settings. 

Notice: **After enabling this option, if the PR does not get the approval of at least one committer or maintainer (whose role with write permission) before the committer comments `/merge`, the committer needs to perform an additional approve operation, or GitHub will prompt this.**

![image](https://user-images.githubusercontent.com/5086433/134448367-7ca5db9f-b083-4b88-b9bb-3e634c253579.png)



