### PR TITLE
config: stop autocc for ticdc

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -984,19 +984,6 @@ ti-community-blunderbuss:
       - 3pointer
       - Little-Wallace
   - repos:
-      - pingcap/ticdc
-    pull_owners_endpoint: https://prow.tidb.io/ti-community-owners
-    max_request_count: 2
-    include_reviewers:
-      - overvenus
-      - amyangfei
-      - liuzix
-      - lonng
-      - JinLingChristopher
-      - ben1009
-      - asddongmen
-      - hi-rustin
-  - repos:
       - pingcap/br
     pull_owners_endpoint: https://prow.tidb.io/ti-community-owners
     max_request_count: 2

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -1018,10 +1018,6 @@ external_plugins:
     - name: ti-community-label-blocker
       events:
         - pull_request
-    - name: ti-community-blunderbuss
-      events:
-        - pull_request
-        - issue_comment
     - name: ti-community-tars
       events:
         - issue_comment


### PR DESCRIPTION
It will cause some people to become review requested hotspots, so we prefer to use random assignment. I will submit an issue to track this requirement. So for now we will do manual randomization.