### PR TITLE
Update config.yaml for DM

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -611,6 +611,7 @@ branch-protection:
                   - "idc-jenkins-ci-dm/compatibility_test"
                   - "idc-jenkins-ci-dm/test"
                   - "license/cla"
+                  - "jenkins-dm/verify"
                 strict: true
             release-2.0:
               protect: true
@@ -621,6 +622,7 @@ branch-protection:
                   - "idc-jenkins-ci-dm/compatibility_test"
                   - "idc-jenkins-ci-dm/test"
                   - "license/cla"
+                  - "jenkins-dm/verify"
                 strict: true
         tidb-tools:
           branches:


### PR DESCRIPTION
related to https://github.com/PingCAP-QE/ci/pull/440 , because we move unit tests from "idc-jenkins-ci-dm/test" to "jenkins-dm/verify", now we should add it to required check.