### PR TITLE
config: update required status for TiCDC

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -663,6 +663,7 @@ branch-protection:
                   - 'idc-jenkins-ci-ticdc/integration-test'
                   - 'idc-jenkins-ci-ticdc/kafka-integration-test'
                   - 'idc-jenkins-ci-ticdc/dm-integration-test'
+                  - 'idc-jenkins-ci-ticdc/dm-compatibility-test'
                   - 'idc-jenkins-ci-ticdc/unit-test'
                   - 'idc-jenkins-ci/leak-test'
                   - 'license/cla'

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -662,6 +662,7 @@ branch-protection:
                 contexts:
                   - 'idc-jenkins-ci-ticdc/integration-test'
                   - 'idc-jenkins-ci-ticdc/kafka-integration-test'
+                  - 'idc-jenkins-ci-ticdc/dm-integration-test'
                   - 'idc-jenkins-ci-ticdc/unit-test'
                   - 'idc-jenkins-ci/leak-test'
                   - 'license/cla'


### PR DESCRIPTION
Since we have merged DM repo into TiCDC repo https://github.com/pingcap/ticdc/pull/3122, we need to add `idc-jenkins-ci-ticdc/dm-integration-test` and `idc-jenkins-ci-ticdc/dm-compatibility-test` as a required status in TiCDC CI.