### PR TITLE
config: limit grammar of the associate issue number

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -1292,7 +1292,7 @@ ti-community-format-checker:
     required_match_rules:
       - pull_request: true
         commit_message: true
-        regexp: "(?i)(see|ref|close[sd]?|resolve[sd]?|fix(e[sd])?)\s*#(?P<issue_number>[1-9]\\d*)"
+        regexp: "(?i)(see|ref|close[sd]?|resolve[sd]?|fix(e[sd])?)\\s*#(?P<issue_number>[1-9]\\d*)"
         missing_message: |
           Please provide the associated issue number in the commit messages, for example: `close #12345`, or `ref #12345`.
         missing_label: do-not-merge/invalid-commit-message

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -1292,7 +1292,7 @@ ti-community-format-checker:
     required_match_rules:
       - pull_request: true
         commit_message: true
-        regexp: "#(?P<issue_number>[1-9]\\d*)"
+        regexp: "(?i)(see|ref|close[sd]?|resolve[sd]?|fix(e[sd])?)\s*#(?P<issue_number>[1-9]\\d*)"
         missing_message: |
           Please provide the associated issue number in the commit messages, for example: `close #12345`, or `ref #12345`.
         missing_label: do-not-merge/invalid-commit-message


### PR DESCRIPTION
As title.

Because the previously configured regular expression is relatively loose, the PR number in the commit message will be incorrectly matched. When the format checker finds that it is not an issue number, it thinks it violates the matching rule.

Therefore, referring to the previous voting content in TiKV community, we restrict the regular expression of format rule.

Ref Vote: https://github.com/tikv/community/pull/150
