### PR TITLE
config(tics): add required status unit-test

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -895,6 +895,7 @@ branch-protection:
               required_status_checks:
                 contexts:
                   - 'tide'
+                  - 'idc-jenkins-ci-tics/unit-test'
                   - 'idc-jenkins-ci-tics/test'
                   - 'idc-jenkins-ci-tics/build'
                 strict: true


### PR DESCRIPTION
releated to https://github.com/pingcap/tics/pull/3321
* tics has a new ci tics_ghpr_unit_test, so add required status unit-test