### PR TITLE
config(pd): enable cherrypicker `copy_issue_numbers_from_squashed_commit` option

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -1312,6 +1312,17 @@ ti-community-cherrypicker:
       - status/LGT3
   - repos:
       - tikv/pd
+    label_prefix: needs-cherry-pick-
+    picked_label_prefix: type/cherry-pick-for-
+    allow_all: true
+    create_issue_on_conflict: false
+    excludeLabels:
+      - status/can-merge
+      - status/LGT1
+      - status/LGT2
+      - status/LGT3
+    copy_issue_numbers_from_squashed_commit: true
+  - repos:
       - pingcap/dm
       - pingcap/br
       - pingcap/tidb-binlog


### PR DESCRIPTION
Now we provided a `copy_issue_numbers_from_squashed_commit` option to make @ti-chi-bot be able to copy the issue number in the squashed commit message to cherry-pick commit when PR is in conflict.

For example, the squashed commit in the master branch has an issue number.

![image](https://user-images.githubusercontent.com/5086433/146168337-ca8c625a-d32f-4599-94c3-4aac8d7acbf9.png)

When PR is in conflict, the bot can't apply the patch that contains the commit history. 

When it generates cherry-pick commit, it will copy issue number from squashed commit to cherry-pick commit.

![image](https://user-images.githubusercontent.com/5086433/146170121-680d7742-cae1-4db9-bce6-7bfd3705cc2c.png)

Refer: https://book.prow.tidb.io/#/plugins/cherrypicker