### PR TITLE
config: enable tichi for ng-monitoring repo

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1218,6 +1218,7 @@ tide:
     pingcap/parser: squash
     pingcap/tics: squash
     pingcap/tiflash: squash
+    pingcap/ng-monitoring: squash
     chaos-mesh/chaos-mesh: squash
     chaos-mesh/website: squash
     chaos-mesh/chaosd: squash
@@ -1287,6 +1288,23 @@ tide:
           {{- " " -}}
         {{- end -}}
     pingcap/tidb-binlog:
+      title: "{{ .Title }} (#{{ .Number }})"
+      body: |
+        {{- $pattern := .Regexp "(?im)^Issue Number:.+" -}}
+        {{- $body := print .Body -}}
+        {{- $org := print .Repository.Owner.Login -}}
+        {{- $repo := print .Repository.Name -}}
+        {{- $issueNumberLine := $pattern.FindString $body -}}
+        {{- $numbers := .NormalizeIssueNumbers $issueNumberLine $org $repo -}}
+        {{- if $numbers -}}
+          {{- range $index, $number := $numbers -}}
+            {{- if $index }}, {{ end -}}
+            {{- .AssociatePrefix }} {{ .Org -}}/{{- .Repo -}}#{{- .Number -}}
+          {{- end -}}
+        {{- else -}}
+          {{- " " -}}
+        {{- end -}}
+    pingcap/ng-monitoring:
       title: "{{ .Title }} (#{{ .Number }})"
       body: |
         {{- $pattern := .Regexp "(?im)^Issue Number:.+" -}}
@@ -1392,6 +1410,7 @@ tide:
         - pingcap/dm
         - pingcap/parser
         - pingcap/tiflash
+        - pingcap/ng-monitoring
         - chaos-mesh/chaos-mesh
         - chaos-mesh/website
         - chaos-mesh/chaosd
@@ -1594,6 +1613,9 @@ tide:
             skip-unknown-contexts: true
             from-branch-protection: true
           tidb:
+            skip-unknown-contexts: true
+            from-branch-protection: true
+          ng-monitoring:
             skip-unknown-contexts: true
             from-branch-protection: true
       chaos-mesh:

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -30,6 +30,7 @@ ti-community-lgtm:
       - pingcap/parser
       - pingcap/tics
       - pingcap/tiflash
+      - pingcap/ng-monitoring
       - chaos-mesh/chaos-mesh
       - chaos-mesh/website
       - chaos-mesh/chaosd
@@ -75,6 +76,7 @@ ti-community-merge:
       - pingcap/parser
       - pingcap/tics
       - pingcap/tiflash
+      - pingcap/ng-monitoring
       - chaos-mesh/chaos-mesh
       - chaos-mesh/website
       - chaos-mesh/chaosd
@@ -343,6 +345,17 @@ ti-community-owners:
       - pingcap/tiflash
     default_require_lgtm: 1
     use_github_permission: true
+    sig_endpoint: https://bots.tidb.io/ti-community-bot
+    require_lgtm_label_prefix: require-LGT
+  - repos:
+      - pingcap/ng-monitoring
+    default_require_lgtm: 1
+    use_github_team: true
+    committer_teams:
+      - diagnostic-maintainers
+      - diagnostic-committers
+    reviewer_teams:
+      - diagnostic-reviewers
     sig_endpoint: https://bots.tidb.io/ti-community-bot
     require_lgtm_label_prefix: require-LGT
   - repos:
@@ -1199,6 +1212,7 @@ ti-community-tars:
       - pingcap/tidb-tools
       - pingcap/tidb-dashboard
       - pingcap/parser
+      - pingcap/ng-monitoring
       - ti-community-infra/test-prod
       - ti-community-infra/ti-challenge-bot
     only_when_label: "status/can-merge"
@@ -1330,6 +1344,7 @@ ti-community-cherrypicker:
       - pingcap/tics
       - pingcap/tiflash
       - pingcap/test-plan
+      - pingcap/ng-monitoring
     label_prefix: needs-cherry-pick-
     picked_label_prefix: type/cherry-pick-for-
     allow_all: true

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -350,12 +350,7 @@ ti-community-owners:
   - repos:
       - pingcap/ng-monitoring
     default_require_lgtm: 1
-    use_github_team: true
-    committer_teams:
-      - diagnostic-maintainers
-      - diagnostic-committers
-    reviewer_teams:
-      - diagnostic-reviewers
+    use_github_permission: true
     sig_endpoint: https://bots.tidb.io/ti-community-bot
     require_lgtm_label_prefix: require-LGT
   - repos:

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -1207,7 +1207,6 @@ ti-community-tars:
       - pingcap/tidb-tools
       - pingcap/tidb-dashboard
       - pingcap/parser
-      - pingcap/ng-monitoring
       - ti-community-infra/test-prod
       - ti-community-infra/ti-challenge-bot
     only_when_label: "status/can-merge"

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -370,6 +370,11 @@ plugins:
     - wip
     - size
     - lifecycle
+  pingcap/ng-monitoring:
+    - welcome
+    - assign
+    - hold
+    - wip
   chaos-mesh/chaos-mesh:
     - welcome
     - assign
@@ -1247,6 +1252,28 @@ external_plugins:
         - pull_request
         - issues
   pingcap/test-plan:
+    - name: ti-community-cherrypicker
+      events:
+        - pull_request
+        - issue_comment
+  pingcap/ng-monitoring:
+    - name: ti-community-lgtm
+      events:
+        - pull_request_review
+        - pull_request
+    - name: ti-community-merge
+      events:
+        - issue_comment
+        - pull_request_review_comment
+        - pull_request
+    - name: needs-rebase
+      events:
+        - pull_request
+        - issue_comment
+    - name: ti-community-tars
+      events:
+        - issue_comment
+        - push
     - name: ti-community-cherrypicker
       events:
         - pull_request

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -1270,10 +1270,6 @@ external_plugins:
       events:
         - pull_request
         - issue_comment
-    - name: ti-community-tars
-      events:
-        - issue_comment
-        - push
     - name: ti-community-cherrypicker
       events:
         - pull_request


### PR DESCRIPTION
Enable the following plugins for pingcap/ng-monitoring repo:

- ti-community-lgtm
- ti-community-merge
- [ti-community-cherrypicker](https://book.prow.tidb.io/#/plugins/cherrypicker)
- welcome
- wip
- assign
- hold