### PR TITLE
chore: update chaos-mesh config

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1103,11 +1103,11 @@ branch-protection:
                   - 'idc-jenkins-ci-tiflash/build'
                 strict: true
     chaos-mesh:
-      protect: true
       repos:
         chaos-mesh:
           branches:
             master:
+              protect: true
               required_status_checks:
                 contexts:
                   - "DCO"
@@ -1119,6 +1119,7 @@ branch-protection:
                   - "chaos-mesh/e2e-test"
                 strict: true
             release-1.0:
+              protect: true
               required_status_checks:
                 contexts:
                   - "pull (verify)"
@@ -1128,6 +1129,7 @@ branch-protection:
                   - "chaos-mesh/e2e-test"
                 strict: true
             release-1.1:
+              protect: true
               required_status_checks:
                 contexts:
                   - "pull (verify)"
@@ -1137,6 +1139,7 @@ branch-protection:
                   - "chaos-mesh/e2e-test"
                 strict: true
             release-1.2:
+              protect: true
               required_status_checks:
                 contexts:
                   - "pull (verify)"
@@ -1146,6 +1149,7 @@ branch-protection:
                   - "chaos-mesh/e2e-test"
                 strict: true
             release-2.0:
+              protect: true
               required_status_checks:
                 contexts:
                   - "pull (verify)"
@@ -1155,6 +1159,7 @@ branch-protection:
                   - "chaos-mesh/e2e-test"
                 strict: true
             release-2.1:
+              protect: true
               required_status_checks:
                 contexts:
                   - "DCO"

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1103,11 +1103,22 @@ branch-protection:
                   - 'idc-jenkins-ci-tiflash/build'
                 strict: true
     chaos-mesh:
+      protect: true
       repos:
         chaos-mesh:
           branches:
             master:
-              protect: true
+              required_status_checks:
+                contexts:
+                  - "DCO"
+                  - "go (build)"
+                  - "go (test)"
+                  - "go (verify)"
+                  - "ui (build)"
+                  - "ui (test)"
+                  - "chaos-mesh/e2e-test"
+                strict: true
+            release-1.0:
               required_status_checks:
                 contexts:
                   - "pull (verify)"
@@ -1117,7 +1128,6 @@ branch-protection:
                   - "chaos-mesh/e2e-test"
                 strict: true
             release-1.1:
-              protect: true
               required_status_checks:
                 contexts:
                   - "pull (verify)"
@@ -1127,7 +1137,6 @@ branch-protection:
                   - "chaos-mesh/e2e-test"
                 strict: true
             release-1.2:
-              protect: true
               required_status_checks:
                 contexts:
                   - "pull (verify)"
@@ -1136,14 +1145,35 @@ branch-protection:
                   - "DCO"
                   - "chaos-mesh/e2e-test"
                 strict: true
+            release-2.0:
+              required_status_checks:
+                contexts:
+                  - "pull (verify)"
+                  - "pull (build)"
+                  - "pull (test)"
+                  - "DCO"
+                  - "chaos-mesh/e2e-test"
+                strict: true
+            release-2.1:
+              required_status_checks:
+                contexts:
+                  - "DCO"
+                  - "go (build)"
+                  - "go (test)"
+                  - "go (verify)"
+                  - "ui (build)"
+                  - "ui (test)"
+                  - "chaos-mesh/e2e-test"
+                strict: true
         website:
+          enforce_admins: false
           branches:
             master:
               protect: true
               required_status_checks:
                 contexts:
-                  - "tide"
                   - "DCO"
+                  - "test"
                 strict: false
         chaosd:
           branches:

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -922,6 +922,8 @@ ti-community-label:
       - status
       - type
     additional_labels:
+      - 'bugbash'
+      - 'contribution'
       - 'DNM'
       - 'Hacktoberfest'
       - 'dependencies'
@@ -936,7 +938,7 @@ ti-community-label:
       - 'needs-cherry-pick-1.1'
       - 'needs-cherry-pick-1.2'
       - 'needs-cherry-pick-2.0'
-      - 'website'
+      - 'needs-cherry-pick-2.1'
       - 'require-LGT3'
     exclude_labels:
       - status/can-merge
@@ -1149,6 +1151,7 @@ ti-community-blunderbuss:
       - Hexilee
       - AsterNighT
       - shivanshs9
+      - iguoyr
   - repos:
       - chaos-mesh/chaosd
     pull_owners_endpoint: https://prow.tidb.io/ti-community-owners
@@ -1169,6 +1172,7 @@ ti-community-blunderbuss:
       - Hexilee
       - AsterNighT
       - shivanshs9
+      - iguoyr
   - repos:
       - pingcap/docs
     pull_owners_endpoint: https://prow.tidb.io/ti-community-owners

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -120,8 +120,9 @@ blockades:
       - chaos-mesh/website
     blockregexps:
       - ^docs/
+      - ^versioned_docs/
     explanation: |
-      This PR modifies the files under the docs folder and requires the docs team to follow up on the PR.
+      This PR modifies the files under the docs or versioned_docs folder and requires the docs team to follow up on the PR.
 
       /label docs
 


### PR DESCRIPTION
Signed-off-by: Yue Yang <g1enyy0ung@gmail.com>

This PR updates the following:

- Update `chaos-mesh/chaos-mesh => required_status_checks => contexts`, we have recently updated the relevant checks in https://github.com/chaos-mesh/chaos-mesh/pull/2696. (This will influence the branch `master` and `release-2.1`)
- Update `chaos-mesh/website => enforce_admins` to `false`. Usually, our docs publishing is a very sampled process, so I thought the `admin` could just push to the master branch.
- Add `test` context to `chaos-mesh/website => required_status_checks`. This ensures that every change is built properly.
- Update `chaos-mesh/chaos-mesh => additional_labels`.
- Add `iguoyr` into `reviewers`.
- Add `^versioned_docs/` regexp to indicate that the document under it needs to be tracked by the docs team.

PTAL. 🍺