### PR TITLE
config: rename pingcap/tiflash to pingcap/tiflash-scripts

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1380,7 +1380,7 @@ tide:
     pingcap/tidb-binlog: squash
     pingcap/parser: squash
     pingcap/tics: squash
-    pingcap/tiflash: squash
+    pingcap/tiflash-scripts: squash
     pingcap/ng-monitoring: squash
     chaos-mesh/chaos-mesh: squash
     chaos-mesh/website: squash
@@ -1547,7 +1547,7 @@ tide:
     pingcap/tics:
       title: "{{ .Title }} (#{{ .Number }})"
       body: " "
-    pingcap/tiflash:
+    pingcap/tiflash-scripts:
       title: "{{ .Title }} (#{{ .Number }})"
       body: " "
     chaos-mesh:
@@ -1593,7 +1593,7 @@ tide:
         - pingcap/docs-appdev
         - pingcap/dm
         - pingcap/parser
-        - pingcap/tiflash
+        - pingcap/tiflash-scripts
         - pingcap/ng-monitoring
         - chaos-mesh/chaos-mesh
         - chaos-mesh/website

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1098,56 +1098,56 @@ branch-protection:
               required_status_checks:
                 contexts:
                   - 'tide'
-                  - 'idc-jenkins-ci-tiflash/test'
-                  - 'idc-jenkins-ci-tiflash/build'
+                  - 'idc-jenkins-ci-tiflash-scripts/test'
+                  - 'idc-jenkins-ci-tiflash-scripts/build'
                 strict: true
             release-4.0:
               protect: true
               required_status_checks:
                 contexts:
                   - 'tide'
-                  - 'idc-jenkins-ci-tiflash/test'
-                  - 'idc-jenkins-ci-tiflash/build'
+                  - 'idc-jenkins-ci-tiflash-scripts/test'
+                  - 'idc-jenkins-ci-tiflash-scripts/build'
                 strict: true
             release-5.0:
               protect: true
               required_status_checks:
                 contexts:
                   - 'tide'
-                  - 'idc-jenkins-ci-tiflash/test'
-                  - 'idc-jenkins-ci-tiflash/build'
+                  - 'idc-jenkins-ci-tiflash-scripts/test'
+                  - 'idc-jenkins-ci-tiflash-scripts/build'
                 strict: true
             release-5.1:
               protect: true
               required_status_checks:
                 contexts:
                   - 'tide'
-                  - 'idc-jenkins-ci-tiflash/test'
-                  - 'idc-jenkins-ci-tiflash/build'
+                  - 'idc-jenkins-ci-tiflash-scripts/test'
+                  - 'idc-jenkins-ci-tiflash-scripts/build'
                 strict: true
             release-5.2:
               protect: true
               required_status_checks:
                 contexts:
                   - 'tide'
-                  - 'idc-jenkins-ci-tiflash/test'
-                  - 'idc-jenkins-ci-tiflash/build'
+                  - 'idc-jenkins-ci-tiflash-scripts/test'
+                  - 'idc-jenkins-ci-tiflash-scripts/build'
                 strict: true
             release-5.3:
               protect: true
               required_status_checks:
                 contexts:
                   - 'tide'
-                  - 'idc-jenkins-ci-tiflash/test'
-                  - 'idc-jenkins-ci-tiflash/build'
+                  - 'idc-jenkins-ci-tiflash-scripts/test'
+                  - 'idc-jenkins-ci-tiflash-scripts/build'
                 strict: true
             release-5.4:
               protect: true
               required_status_checks:
                 contexts:
                   - 'tide'
-                  - 'idc-jenkins-ci-tiflash/test'
-                  - 'idc-jenkins-ci-tiflash/build'
+                  - 'idc-jenkins-ci-tiflash-scripts/test'
+                  - 'idc-jenkins-ci-tiflash-scripts/build'
                 strict: true
     chaos-mesh:
       repos:

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1091,7 +1091,7 @@ branch-protection:
                   - 'idc-jenkins-ci-tics/integration-test'
                   - 'idc-jenkins-ci-tics/build'
                 strict: true
-        tiflash:
+        tiflash-scripts:
           branches:
             master:
               protect: true

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -29,7 +29,7 @@ ti-community-lgtm:
       - pingcap/tidb-binlog
       - pingcap/parser
       - pingcap/tics
-      - pingcap/tiflash
+      - pingcap/tiflash-scripts
       - pingcap/ng-monitoring
       - chaos-mesh/chaos-mesh
       - chaos-mesh/website
@@ -75,7 +75,7 @@ ti-community-merge:
       - pingcap/tidb-binlog
       - pingcap/parser
       - pingcap/tics
-      - pingcap/tiflash
+      - pingcap/tiflash-scripts
       - pingcap/ng-monitoring
       - chaos-mesh/chaos-mesh
       - chaos-mesh/website
@@ -363,7 +363,7 @@ ti-community-owners:
     require_lgtm_label_prefix: require-LGT
   - repos:
       - pingcap/tics
-      - pingcap/tiflash
+      - pingcap/tiflash-scripts
     default_require_lgtm: 1
     use_github_permission: true
     sig_endpoint: https://bots.tidb.io/ti-community-bot
@@ -893,7 +893,7 @@ ti-community-label:
     exclude_labels:
       - status/can-merge
   - repos:
-      - pingcap/tiflash
+      - pingcap/tiflash-scripts
     prefixes:
       - status
       - found
@@ -1023,7 +1023,7 @@ ti-community-autoresponder:
   - repos:
       - tikv/tikv
       - pingcap/tics
-      - pingcap/tiflash
+      - pingcap/tiflash-scripts
     auto_responds:
       - regex: "(?mi)^/merge\\s*$"
         message: |
@@ -1227,7 +1227,7 @@ ti-community-tars:
       - pingcap/br
       - pingcap/tidb-binlog
       - pingcap/tics
-      - pingcap/tiflash
+      - pingcap/tiflash-scripts
       - chaos-mesh/chaos-mesh
       - chaos-mesh/chaosd
     only_when_label: "status/can-merge"
@@ -1275,7 +1275,7 @@ ti-community-label-blocker:
       - pingcap/tidb
       - pingcap/parser
       - pingcap/tics
-      - pingcap/tiflash
+      - pingcap/tiflash-scripts
       - pingcap/docs
       - pingcap/docs-cn
       - pingcap/docs-dm
@@ -1394,7 +1394,7 @@ ti-community-cherrypicker:
       - pingcap/tidb-binlog
       - pingcap/parser
       - pingcap/tics
-      - pingcap/tiflash
+      - pingcap/tiflash-scripts
       - pingcap/test-plan
       - pingcap/ng-monitoring
     label_prefix: needs-cherry-pick-

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -30,7 +30,7 @@ welcome:
       - pingcap/tidb-binlog
       - pingcap/parser
       - pingcap/tics
-      - pingcap/tiflash
+      - pingcap/tiflash-scripts
       - chaos-mesh/chaos-mesh
       - chaos-mesh/website
       - chaos-mesh/chaosd
@@ -364,7 +364,7 @@ plugins:
     - lifecycle
     - release-note
     - cherry-pick-unapproved
-  pingcap/tiflash:
+  pingcap/tiflash-scripts:
     - welcome
     - assign
     - hold
@@ -1244,7 +1244,7 @@ external_plugins:
         - pull_request_review
         - pull_request
         - issues
-  pingcap/tiflash:
+  pingcap/tiflash-scripts:
     - name: ti-community-lgtm
       events:
         - pull_request_review


### PR DESCRIPTION
Signed-off-by: Schrodinger ZHU Yifan <i@zhuyi.fan>

TiFlash is in the progress of renaming the repos. This PR moves integration scripts to a separate `tiflash-scripts` repo,  allowing main source repo to claim the name of `tiflash`.

The change is triggered by:
```
sed -i "s/pingcap\/tiflash/pingcap\/tiflash-scripts/g" $(find . -type f)
```