### PR TITLE
change checks for chaos-mesh on master branch

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1303,7 +1303,7 @@ branch-protection:
                   - "go (verify)"
                   - "ui (build)"
                   - "ui (test)"
-                  - "chaos-mesh/e2e-test"
+                  - "E2E Test Passed"
                 strict: true
             release-1.0:
               protect: true


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

Hi! We have migrated the e2e test from Jenkins to GitHub Action(https://github.com/chaos-mesh/chaos-mesh/pull/2986), the name of the check has been changed. This PR would update the configuration of the bot.