### PR TITLE
chore: apply gha e2e test on release-2.1

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1382,7 +1382,7 @@ branch-protection:
                   - "go (verify)"
                   - "ui (build)"
                   - "ui (test)"
-                  - "chaos-mesh/e2e-test"
+                  - "E2E Test Passed"
                 strict: true
         website:
           enforce_admins: false


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

This PR would update the configuration of checks from Jenkins to GitHub Action.

Like https://github.com/ti-community-infra/configs/pull/550, but for release-2.1