### PR TITLE
config: fix docs-cn jenkins ci name

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -697,7 +697,7 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
-                  - "jenkins-docs/verify"
+                  - "jenkins-docs-cn/verify"
                   - "pull"
                   - "license/cla"
                   - "tide"


### PR DESCRIPTION
missing `-cn`