### PR TITLE
config: enable issue triage check for tikv and pd

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1806,6 +1806,7 @@ tide:
         - do-not-merge/work-in-progress
         - do-not-merge/blocked-paths
         - do-not-merge/needs-linked-issue
+        - do-not-merge/needs-triage-completed
         - needs-rebase
       reviewApprovedRequired: true
     - repos:
@@ -1830,6 +1831,7 @@ tide:
         - do-not-merge/cherry-pick-not-approved
         - do-not-merge/blocked-paths
         - do-not-merge/needs-linked-issue
+        - do-not-merge/needs-triage-completed
         - needs-rebase
     - repos:
         - pingcap/dumpling

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -1559,10 +1559,10 @@ ti-community-format-checker:
           - master    # Temporarily only check the PRs on the master branch.
         regexp: "(?im)^Issue Number:\\s*((,\\s*)?(ref|close[sd]?|resolve[sd]?|fix(e[sd])?)\\s*((https|http)://github\\.com/{{.Org}}/{{.Repo}}/issues/|{{.Org}}/{{.Repo}}#|#)(?P<issue_number>[1-9]\\d*))+"
         missing_message: |
-          **Notice**: Please provide the linked issue number on one line in the PR body, for example: `Issue Number: close #123` or `Issue Number: ref #456`, multiple issues should use full syntax for each issue and be separated by a comma, like: `Issue Number: close #123, ref #456`.
+          **Notice**: To remove the `do-not-merge/needs-linked-issue` label, please provide the linked issue number on one line in the PR body, for example: `Issue Number: close #123` or `Issue Number: ref #456`, multiple issues should use full syntax for each issue and be separated by a comma, like: `Issue Number: close #123, ref #456`.
 
           <sub>:open_book: For more info, you can check the ["Linking issues"](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md#linking-issues) section in the [CONTRIBUTING.md](https://github.com/tikv/tikv/blob/master/CONTRIBUTING.md).</sub>
-        start_time: "2022-02-01T00:00:00+08:00"   # Temporarily, only PRs created after 2022/02/01 will be checked.
+        missing_label: do-not-merge/needs-linked-issue
         skip_label: skip-issue-check
 
 

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -1580,6 +1580,7 @@ ti-community-issue-triage:
     status_target_url: "https://book.prow.tidb.io/#/en/plugins/issue-triage"
   - repos:
       - pingcap/tidb
+      - tikv/tikv
     maintain_versions:
       - "4.0"
       - "5.0"
@@ -1596,6 +1597,7 @@ ti-community-issue-triage:
   - repos:
       - pingcap/tiflow
       - pingcap/tiflash
+      - tikv/pd
     maintain_versions:
       - "4.0"
       - "5.0"

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -683,6 +683,11 @@ external_plugins:
     - name: ti-community-format-checker
       events:
         - pull_request
+    - name: ti-community-issue-triage
+      events:
+        - issues
+        - pull_request
+        - issue_comment
   pingcap/tidb-dashboard:
     - name: ti-community-lgtm
       events:
@@ -803,6 +808,11 @@ external_plugins:
     - name: ti-community-format-checker
       events:
         - pull_request
+    - name: ti-community-issue-triage
+      events:
+        - issues
+        - pull_request
+        - issue_comment
   pingcap/tidb:
     - name: ti-community-lgtm
       events:


### PR DESCRIPTION
- [enforce link issue check for tikv repos](https://github.com/ti-community-infra/configs/pull/558/commits/400b0b71b9d98b0468e7ae020790835235020840)
- [enable issue triage check for tikv and pd](https://github.com/ti-community-infra/configs/pull/558/commits/709a472bac217f9b3a17ce182e87ff41d3151750)
- [needs triage completed before merged on master](https://github.com/ti-community-infra/configs/pull/558/commits/8decf3b33b0864af1f63a4faaa98e99e1eacfb26)