### PR TITLE
config: remove unnecessary tikv release build

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -2003,7 +2003,6 @@ tide:
             # master / release-3.0 / release-3.1 / release-4.0 / release-5.x.
             required-contexts:
               - "DCO"
-              - "idc-jenkins-ci-tikv/build"
               - "idc-jenkins-ci/test"
               - "tide"
             skip-unknown-contexts: true


### PR DESCRIPTION
* tikv release build take too long, tidb_ghpr_test already has debug build on linux amd64. remove tidb_ghpr_build ci pipeline.