### PR TITLE
config(ticdc): make tide required for tiflow

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -971,6 +971,7 @@ branch-protection:
                   - 'idc-jenkins-ci/leak-test'
                   - 'license/cla'
                   - "check-issue-triage-complete"
+                  - "tide"
                 strict: true
             release-4.0:
               protect: true
@@ -981,6 +982,7 @@ branch-protection:
                   - 'idc-jenkins-ci-ticdc/unit-test'
                   - 'idc-jenkins-ci/leak-test'
                   - 'license/cla'
+                  - "tide"
                 strict: true
             release-5.0:
               protect: true
@@ -991,6 +993,7 @@ branch-protection:
                   - 'idc-jenkins-ci-ticdc/unit-test'
                   - 'idc-jenkins-ci/leak-test'
                   - 'license/cla'
+                  - "tide"
                 strict: true
             release-5.1:
               protect: true
@@ -1001,6 +1004,7 @@ branch-protection:
                   - 'idc-jenkins-ci-ticdc/unit-test'
                   - 'idc-jenkins-ci/leak-test'
                   - 'license/cla'
+                  - "tide"
                 strict: true
             release-5.2:
               protect: true
@@ -1011,6 +1015,7 @@ branch-protection:
                   - 'idc-jenkins-ci-ticdc/unit-test'
                   - 'idc-jenkins-ci/leak-test'
                   - 'license/cla'
+                  - "tide"
                 strict: true
             release-5.3:
               protect: true
@@ -1023,6 +1028,7 @@ branch-protection:
                   - 'idc-jenkins-ci-ticdc/unit-test'
                   - 'idc-jenkins-ci/leak-test'
                   - 'license/cla'
+                  - "tide"
                 strict: true
             release-5.4:
               protect: true
@@ -1035,6 +1041,7 @@ branch-protection:
                   - 'idc-jenkins-ci-ticdc/unit-test'
                   - 'idc-jenkins-ci/leak-test'
                   - 'license/cla'
+                  - "tide"
                 strict: true
             release-6.0:
               protect: true
@@ -1047,6 +1054,7 @@ branch-protection:
                   - 'idc-jenkins-ci-ticdc/unit-test'
                   - 'idc-jenkins-ci/leak-test'
                   - 'license/cla'
+                  - "tide"
                 strict: true
         tidb-binlog:
           branches:


### PR DESCRIPTION
Set tide as a required item to prevent people from merging by mistake.