### PR TITLE
update binlog config to allow pick LGT labels

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -1493,7 +1493,6 @@ ti-community-cherrypicker:
   - repos:
       - pingcap/dm
       - pingcap/br
-      - pingcap/tidb-binlog
       - pingcap/parser
       - pingcap/tiflash
       - pingcap/tiflash-scripts
@@ -1511,6 +1510,7 @@ ti-community-cherrypicker:
       - status/LGT3
   - repos:
       - pingcap/tiflow
+      - pingcap/tidb-binlog
     label_prefix: needs-cherry-pick-
     picked_label_prefix: type/cherry-pick-for-
     allow_all: true


### PR DESCRIPTION
binlog doesn't have many reviewers checking cherry-picked PRs. Most cherry-pick PRs don't need review again.