### PR TITLE
chore: append xlgao-zju as chaos mesh committer

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -1292,6 +1292,7 @@ ti-community-blunderbuss:
       - AsterNighT
       - shivanshs9
       - iguoyr
+      - xlgao-zju
   - repos:
       - chaos-mesh/chaosd
     pull_owners_endpoint: https://prow.tidb.io/ti-community-owners
@@ -1313,6 +1314,7 @@ ti-community-blunderbuss:
       - AsterNighT
       - shivanshs9
       - iguoyr
+      - xlgao-zju
   - repos:
       - pingcap/docs
     pull_owners_endpoint: https://prow.tidb.io/ti-community-owners


### PR DESCRIPTION
Signed-off-by: STRRL <im@strrl.dev>

as https://github.com/chaos-mesh/chaos-mesh/pull/3317 is going to be merged, I create this PR for updating the taichi bot configuration