### PR TITLE
chore: new branch release-2.3 for chaos mesh

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1710,6 +1710,18 @@ branch-protection:
                   - "ui (build)"
                   - "ui (test)"
                   - "E2E Test Passed"
+                strict: true 
+            release-2.3:
+              protect: true
+              required_status_checks:
+                contexts:
+                  - "DCO"
+                  - "go (build)"
+                  - "go (test)"
+                  - "go (verify)"
+                  - "ui (build)"
+                  - "ui (test)"
+                  - "E2E Test Passed"
                 strict: true
         website:
           enforce_admins: false

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -1136,6 +1136,7 @@ ti-community-label:
       - "needs-cherry-pick-2.0"
       - "needs-cherry-pick-2.1"
       - "needs-cherry-pick-2.2"
+      - "needs-cherry-pick-2.3"
       - "require-LGT3"
     exclude_labels:
       - status/can-merge


### PR DESCRIPTION
Signed-off-by: STRRL <str_ruiling@outlook.com>

Chaos Mesh just cut the new branch release-2.3 for the next minor release v2.3.0 and related beta releases, this PR would update the tichi bot configurations.