### PR TITLE
fix: modify chaos-mesh release-2.3 required status check

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1716,9 +1716,12 @@ branch-protection:
               required_status_checks:
                 contexts:
                   - "DCO"
-                  - "go (build)"
-                  - "go (test)"
-                  - "go (verify)"
+                  - "go (amd64, build)"
+                  - "go (amd64, test)"
+                  - "go (amd64, verify)"
+                  - "go (arm64, build)"
+                  - "go (arm64, test)"
+                  - "go (arm64, verify)"
                   - "ui (build)"
                   - "ui (test)"
                   - "E2E Test Passed"


### PR DESCRIPTION
Signed-off-by: YangKeao <yangkeao@chunibyo.icu>

Like what we have done in https://github.com/ti-community-infra/configs/pull/579, we should modify the required check for new release.