### PR TITLE
Config( triage ): Add "6.0" to "wontfix_verions" list.

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -1703,6 +1703,8 @@ ti-community-issue-triage:
       - "5.1"
       - "5.2"
       - "5.3"
+    wontfix_versions:
+      - "6.0"
     affects_label_prefix: "affects/"
     may_affects_label_prefix: "may-affects/"
     linked_issue_needs_triage_label: "do-not-merge/needs-triage-completed"


### PR DESCRIPTION
Version 6.0 has finished it's life cycle.
@wuhuizuo @heipark