### PR TITLE
build(prow/cluster): upgrade k8s manifests to k8s `v1.22`

### DIFF
--- a/prow/cluster/crier_rbac.yaml
+++ b/prow/cluster/crier_rbac.yaml
@@ -42,7 +42,7 @@ rules:
       - "patch"
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: crier
   namespace: prow
@@ -56,7 +56,7 @@ subjects:
     namespace: prow
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: crier
   namespace: prow-test-pods

--- a/prow/cluster/deck_rbac.yaml
+++ b/prow/cluster/deck_rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "deck"
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: prow
   name: "deck"
@@ -18,7 +18,7 @@ subjects:
     name: "deck"
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: prow-test-pods
   name: "deck"
@@ -32,7 +32,7 @@ subjects:
     namespace: prow
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: prow
   name: "deck"
@@ -51,7 +51,7 @@ rules:
       # - create
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: prow-test-pods
   name: "deck"

--- a/prow/cluster/hook_rbac.yaml
+++ b/prow/cluster/hook_rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "hook"
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: prow
   name: "hook"
@@ -29,7 +29,7 @@ rules:
       - update
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: prow
   name: "hook"

--- a/prow/cluster/horologium_rbac.yaml
+++ b/prow/cluster/horologium_rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "horologium"
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: prow
   name: "horologium"
@@ -19,7 +19,7 @@ rules:
       - list
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: prow
   name: "horologium"

--- a/prow/cluster/ing_ingress.yaml
+++ b/prow/cluster/ing_ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: prow
@@ -14,25 +14,40 @@ spec:
       http:
         paths:
           - path: /*
+            pathType: ImplementationSpecific
             backend:
-              serviceName: deck
-              servicePort: 80
+              service:
+                name: deck
+                port: 
+                  number: 80
           - path: /hook
+            pathType: ImplementationSpecific
             backend:
-              serviceName: hook
-              servicePort: 8888
+              service:
+                name: hook
+                port: 
+                  number: 8888
           - path: /ti-community-owners/*
+            pathType: ImplementationSpecific
             backend:
-              serviceName: ti-community-owners
-              servicePort: 80
+              service:
+                name: ti-community-owners
+                port: 
+                  number: 80
           - path: /tichi
+            pathType: ImplementationSpecific
             backend:
-              serviceName: tichi-web
-              servicePort: 80
+              service:
+                name: tichi-web
+                port: 
+                  number: 80
           - path: /tichi/*
+            pathType: ImplementationSpecific
             backend:
-              serviceName: tichi-web
-              servicePort: 80
+              service:
+                name: tichi-web
+                port: 
+                  number: 80
   tls:
     - hosts:
         - "*.tidb.io"

--- a/prow/cluster/prow_controller_manager_rbac.yaml
+++ b/prow/cluster/prow_controller_manager_rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: prow-controller-manager
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: prow
   name: prow-controller-manager
@@ -53,7 +53,7 @@ rules:
       - create
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: prow-test-pods
   name: prow-controller-manager
@@ -70,7 +70,7 @@ rules:
       - patch
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: prow
   name: prow-controller-manager
@@ -83,7 +83,7 @@ subjects:
     name: prow-controller-manager
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: prow-test-pods
   name: prow-controller-manager

--- a/prow/cluster/prowjob_customresourcedefinition.yaml
+++ b/prow/cluster/prowjob_customresourcedefinition.yaml
@@ -1,86 +1,96 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+# download from https://raw.githubusercontent.com/kubernetes/test-infra/master/config/prow/cluster/prowjob-crd/legacy/prowjob-schemaless_customresourcedefinition.yaml
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: prowjobs.prow.k8s.io
+  annotations:
+    "api-approved.kubernetes.io": "https://github.com/kubernetes/test-infra/pull/8669"
 spec:
   group: prow.k8s.io
-  version: v1
   names:
     kind: ProwJob
     singular: prowjob
     plural: prowjobs
   scope: Namespaced
-  validation:
-    openAPIV3Schema:
-      properties:
-        spec:
-          properties:
-            max_concurrency:
-              type: integer
-              minimum: 0
-            type:
-              type: string
-              enum:
+  versions:
+  - name: v1
+    served: true
+    storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              max_concurrency:
+                type: integer
+                minimum: 0
+              type:
+                type: string
+                enum:
                 - "presubmit"
                 - "postsubmit"
                 - "periodic"
                 - "batch"
-        status:
-          properties:
-            state:
-              type: string
-              enum:
+          status:
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            properties:
+              state:
+                type: string
+                enum:
                 - "triggered"
                 - "pending"
                 - "success"
                 - "failure"
                 - "aborted"
                 - "error"
-          anyOf:
+            anyOf:
             - not:
                 properties:
                   state:
-                    type: string
                     enum:
-                      - "success"
-                      - "failure"
-                      - "error"
+                    - "success"
+                    - "failure"
+                    - "error"
             - required:
-                - completionTime
-  additionalPrinterColumns:
+              - completionTime
+    additionalPrinterColumns:
     - name: Job
       type: string
       description: The name of the job being run.
-      JSONPath: .spec.job
+      jsonPath: .spec.job
     - name: BuildId
       type: string
       description: The ID of the job being run.
-      JSONPath: .status.build_id
+      jsonPath: .status.build_id
     - name: Type
       type: string
       description: The type of job being run.
-      JSONPath: .spec.type
+      jsonPath: .spec.type
     - name: Org
       type: string
       description: The org for which the job is running.
-      JSONPath: .spec.refs.org
+      jsonPath: .spec.refs.org
     - name: Repo
       type: string
       description: The repo for which the job is running.
-      JSONPath: .spec.refs.repo
+      jsonPath: .spec.refs.repo
     - name: Pulls
       type: string
       description: The pulls for which the job is running.
-      JSONPath: ".spec.refs.pulls[*].number"
+      jsonPath: ".spec.refs.pulls[*].number"
     - name: StartTime
       type: date
       description: When the job started running.
-      JSONPath: .status.startTime
+      jsonPath: .status.startTime
     - name: CompletionTime
       type: date
       description: When the job finished running.
-      JSONPath: .status.completionTime
+      jsonPath: .status.completionTime
     - name: State
       description: The state of the job.
       type: string
-      JSONPath: .status.state
+      jsonPath: .status.state

--- a/prow/cluster/sinker_rbac.yaml
+++ b/prow/cluster/sinker_rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "sinker"
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: prow
   name: "sinker"
@@ -52,7 +52,7 @@ rules:
       - create
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: prow-test-pods
   name: "sinker"
@@ -69,7 +69,7 @@ rules:
       - patch
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: prow
   name: "sinker"
@@ -82,7 +82,7 @@ subjects:
     name: "sinker"
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: prow-test-pods
   name: "sinker"

--- a/prow/cluster/statusreconciler_rbac.yaml
+++ b/prow/cluster/statusreconciler_rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "statusreconciler"
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: prow
   name: "statusreconciler"
@@ -18,7 +18,7 @@ rules:
       - create
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: prow
   name: "statusreconciler"

--- a/prow/cluster/tide_rbac.yaml
+++ b/prow/cluster/tide_rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   name: "tide"
 ---
 kind: Role
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: prow
   name: "tide"
@@ -21,7 +21,7 @@ rules:
       - watch
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   namespace: prow
   name: "tide"


### PR DESCRIPTION
Ref:
- https://cloud.google.com/kubernetes-engine/docs/deprecations/apis-1-22?_ga=2.123900106.-1597814552.1659254325#v1-manifest
- https://raw.githubusercontent.com/kubernetes/test-infra/master/config/prow/cluster/prowjob-crd/prowjob_customresourcedefinition.yaml
<img width="575" alt="截屏2022-08-27 18 07 24" src="https://user-images.githubusercontent.com/2574558/187025580-0836bfd2-9ca1-4dff-9022-a4d4f4c3bcf5.png">
