### PR TITLE
config(tiflow): remove required status check of leak-test in part of branches

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1126,7 +1126,6 @@ branch-protection:
                   - "idc-jenkins-ci-ticdc/dm-integration-test"
                   - "idc-jenkins-ci-ticdc/dm-compatibility-test"
                   - "jenkins-ticdc/verify"
-                  - "idc-jenkins-ci/leak-test"
                   - "license/cla"
                   - "check-issue-triage-complete"
                   - "tide"
@@ -1196,8 +1195,7 @@ branch-protection:
                   - "idc-jenkins-ci-ticdc/kafka-integration-test"
                   - "idc-jenkins-ci-ticdc/dm-integration-test"
                   - "idc-jenkins-ci-ticdc/dm-compatibility-test"
-                  - "idc-jenkins-ci-ticdc/unit-test"
-                  - "idc-jenkins-ci/leak-test"
+                  - "jenkins-ticdc/verify"
                   - "license/cla"
                   - "tide"
                 strict: true
@@ -1209,8 +1207,7 @@ branch-protection:
                   - "idc-jenkins-ci-ticdc/kafka-integration-test"
                   - "idc-jenkins-ci-ticdc/dm-integration-test"
                   - "idc-jenkins-ci-ticdc/dm-compatibility-test"
-                  - "idc-jenkins-ci-ticdc/unit-test"
-                  - "idc-jenkins-ci/leak-test"
+                  - "jenkins-ticdc/verify"
                   - "license/cla"
                   - "tide"
                 strict: true
@@ -1222,8 +1219,7 @@ branch-protection:
                   - "idc-jenkins-ci-ticdc/kafka-integration-test"
                   - "idc-jenkins-ci-ticdc/dm-integration-test"
                   - "idc-jenkins-ci-ticdc/dm-compatibility-test"
-                  - "idc-jenkins-ci-ticdc/unit-test"
-                  - "idc-jenkins-ci/leak-test"
+                  - "jenkins-ticdc/verify"
                   - "license/cla"
                   - "tide"
                 strict: true
@@ -1235,8 +1231,7 @@ branch-protection:
                   - "idc-jenkins-ci-ticdc/kafka-integration-test"
                   - "idc-jenkins-ci-ticdc/dm-integration-test"
                   - "idc-jenkins-ci-ticdc/dm-compatibility-test"
-                  - "idc-jenkins-ci-ticdc/unit-test"
-                  - "idc-jenkins-ci/leak-test"
+                  - "jenkins-ticdc/verify"
                   - "license/cla"
                   - "tide"
                 strict: true
@@ -1246,8 +1241,6 @@ branch-protection:
                 contexts:
                   - "idc-jenkins-ci-ticdc/integration-test"
                   - "idc-jenkins-ci-ticdc/kafka-integration-test"
-                  - "idc-jenkins-ci-ticdc/unit-test"
-                  - "idc-jenkins-ci/leak-test"
                   - "jenkins-ticdc/verify"
                   - "license/cla"
                   - "tide"


### PR DESCRIPTION
ref task-3 in https://github.com/pingcap/tiflow/issues/6094
`jenkins-ticdc/verify` has covered all tests included in `idc-jenkins-ci/leak-test` and `idc-jenkins-ci-ticdc/unit-test`


Besides I can't find the test entrance of `idc-jenkins-ci/leak-test`, maybe there are configured in Jenkins backend.

`jenkins-ticdc/verify` is added since release-5.4, we can remove `idc-jenkins-ci/leak-test` from release-5.4