### PR TITLE
chore(prow/cluster): add ingress to prow.prow.net

### DIFF
--- a/prow/cluster/ing_ingress.yaml
+++ b/prow/cluster/ing_ingress.yaml
@@ -18,40 +18,95 @@ spec:
             backend:
               service:
                 name: deck
-                port: 
+                port:
                   number: 80
           - path: /hook
             pathType: ImplementationSpecific
             backend:
               service:
                 name: hook
-                port: 
+                port:
                   number: 8888
           - path: /ti-community-owners/*
             pathType: ImplementationSpecific
             backend:
               service:
                 name: ti-community-owners
-                port: 
+                port:
                   number: 80
           - path: /tichi
             pathType: ImplementationSpecific
             backend:
               service:
                 name: tichi-web
-                port: 
+                port:
                   number: 80
           - path: /tichi/*
             pathType: ImplementationSpecific
             backend:
               service:
                 name: tichi-web
-                port: 
+                port:
                   number: 80
   tls:
     - hosts:
         - "*.tidb.io"
       secretName: prow-tidb-io
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: prow-net
+  namespace: prow
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: prow-tidb-net-ip
+    kubernetes.io/ingress.class: "gce"
+    networking.gke.io/v1beta1.FrontendConfig: ingress-security-config
+    kubernetes.io/ingress.allow-http: "true"
+spec:
+  rules:
+    - host: prow.tidb.net
+      http:
+        paths:
+          - path: /*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: deck
+                port:
+                  number: 80
+          - path: /hook
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: hook
+                port:
+                  number: 8888
+          - path: /ti-community-owners/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: ti-community-owners
+                port:
+                  number: 80
+          - path: /tichi
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: tichi-web
+                port:
+                  number: 80
+          - path: /tichi/*
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: tichi-web
+                port:
+                  number: 80
+  tls:
+    - hosts:
+        - "*.tidb.net"
+      secretName: prow-tidb-net
 ---
 apiVersion: networking.gke.io/v1beta1
 kind: FrontendConfig


### PR DESCRIPTION
<!-- Thank you for contributing -->

### What problem does this PR solve?

add ingress to `prow.tidb.net`

### What is changed and how it works?

What's Changed: add a k8s ingress resource `prow-net`
