### PR TITLE
config(tidb): update needs cherry pick labels

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -627,7 +627,7 @@ ti-community-label:
       - "needs-cherry-pick-6.1"
       - "needs-cherry-pick-6.2"
       - "needs-cherry-pick-6.3"
-      # - "needs-cherry-pick-{{.ver}}"
+      # - "needs-cherry-pick-release-{{.ver}}"
       - "affects-4.0"
       - "affects-5.0"
       - "affects-5.1"
@@ -685,7 +685,7 @@ ti-community-label:
       - "needs-cherry-pick-6.1"
       - "needs-cherry-pick-6.2"
       - "needs-cherry-pick-6.3"
-      # - "needs-cherry-pick-{{.ver}}"
+      # - "needs-cherry-pick-release-{{.ver}}"
       - "affects-4.0"
       - "affects-5.0"
       - "affects-5.1"
@@ -1798,6 +1798,31 @@ ti-community-issue-triage:
     status_target_url: "https://book.prow.tidb.net/#/en/plugins/issue-triage"
   - repos:
       - pingcap/tidb
+    maintain_versions:
+      - "4.0"
+      - "5.0"
+      - "5.1"
+      - "5.2"
+      - "5.3"
+      - "5.4"
+      - "6.0"
+      - "6.1"
+      - "6.2"
+      - "6.3"
+    wontfix_versions:
+      - "3.0"
+      - "4.0"
+      - "5.0"
+      - "5.1"
+      - "5.2"
+      - "6.0"
+      - "6.2"
+    affects_label_prefix: "affects-"
+    may_affects_label_prefix: "may-affects-"
+    linked_issue_needs_triage_label: "do-not-merge/needs-triage-completed"
+    need_cherry_pick_label_prefix: "needs-cherry-pick-release-"
+    status_target_url: "https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/cherrypick-a-pr.html#pass-triage-complete-check"
+  - repos:
       - pingcap/br
       - tikv/tikv
     maintain_versions:

--- a/prow/config/labels.yaml
+++ b/prow/config/labels.yaml
@@ -4276,7 +4276,7 @@ repos:
       - name: needs-cherry-pick-6.3
         color: "ededed"
         target: both
-      # - name: needs-cherry-pick-{{.ver}}
+      # - name: needs-cherry-pick-release-{{.ver}}
       #   color: "ededed"
       #   target: both
       - name: Priority/P0


### PR DESCRIPTION
for versions label from `needs-cherry-pick-to-{ .ver }` to `needs-cherry-pick-to-release-{ .ver }`:
 - `6.1`
 - `6.3`
 - `5.3`
 - `5.4`

<!-- Thank you for contributing -->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:
