### PR TITLE
refactor(tikv): update `need_cherry_pick_label_prefix` for tikv

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -1847,7 +1847,7 @@ ti-community-issue-triage:
     affects_label_prefix: "affects-"
     may_affects_label_prefix: "may-affects-"
     linked_issue_needs_triage_label: "do-not-merge/needs-triage-completed"
-    need_cherry_pick_label_prefix: "needs-cherry-pick-"
+    need_cherry_pick_label_prefix: "needs-cherry-pick-release-"
     status_target_url: "https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/cherrypick-a-pr.html#pass-triage-complete-check"
   - repos:
       - pingcap/tiflow


### PR DESCRIPTION
cherry-pick bot will migrate from old cherry-pick bot to TiChiBot's cherry-pick plugin:
- `pingcap/br` is merged into `pingcap/tidb`, no need to split the configuration changes.
- creating of cherry-pick PR for `tikv/tikv` will be migrated to TiChiBot before this PR merged.

BREAKING CHANGE: need to manually rename labels from `needs-cherry-pick-x.y` to `needs-cherry-pick-release-x.y` after the PR merged.

<!-- Thank you for contributing -->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:
