### PR TITLE
fix(ti-community-format-checker): merge tidb ti-community-format-checker configs.

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -1773,14 +1773,14 @@ ti-community-format-checker:
           <sub>:open_book: For more info, you can check the ["Contribute Code"](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#title-format) section in the development guide.</sub>
         missing_label: do-not-merge/invalid-title
         skip_label: skip-issue-check
-  - repos:
-      - pingcap/tidb-tools
-      - pingcap/tidb-binlog
-    required_match_rules:
       - pull_request: true
         body: true
         branches:
           - master
+          - feature/distribute-reorg
+          - feature/flashback-cluster
+          - feature/ddl-as-service
+          - feature/reorganize-partition
         regexp:
           "(?im)^Issue
           Number:\\s*((,\\s*)?(ref|close[sd]?|resolve[sd]?|fix(e[sd])?)\\s*((https|http)://github\\.com/{{.Org}}/{{.Repo}}/issues/|{{.Org}}/{{.Repo}}#|#)(?P<issue_number>[1-9]\\d*))+"
@@ -1791,16 +1791,13 @@ ti-community-format-checker:
         missing_label: do-not-merge/needs-linked-issue
         skip_label: skip-issue-check
   - repos:
-      - pingcap/tidb
+      - pingcap/tidb-tools
+      - pingcap/tidb-binlog
     required_match_rules:
       - pull_request: true
         body: true
         branches:
           - master
-          - feature/distribute-reorg
-          - feature/flashback-cluster
-          - feature/ddl-as-service
-          - feature/reorganize-partition
         regexp:
           "(?im)^Issue
           Number:\\s*((,\\s*)?(ref|close[sd]?|resolve[sd]?|fix(e[sd])?)\\s*((https|http)://github\\.com/{{.Org}}/{{.Repo}}/issues/|{{.Org}}/{{.Repo}}#|#)(?P<issue_number>[1-9]\\d*))+"

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -1772,7 +1772,6 @@ ti-community-format-checker:
 
           <sub>:open_book: For more info, you can check the ["Contribute Code"](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#title-format) section in the development guide.</sub>
         missing_label: do-not-merge/invalid-title
-        skip_label: skip-issue-check
       - pull_request: true
         body: true
         branches:


### PR DESCRIPTION
The separated configs of tidb under ti-community-format-checker may make the second one invalid.