### PR TITLE
fix(prow/cluster): disable report for jenkins-operator comonent

### DIFF
--- a/prow/cluster/jenkins-operator-deployment.yaml
+++ b/prow/cluster/jenkins-operator-deployment.yaml
@@ -28,7 +28,7 @@ spec:
           image: ticommunityinfra/jenkins-operator:v20221223-136fab6d35
           args:
             - --dry-run=false
-            - --skip-report=false
+            - --skip-report=true # avoid dup reporting with crier component
             - --csrf-protect=false
             - --github-token-path=/etc/github/token
             - --config-path=/etc/config/config.yaml


### PR DESCRIPTION
it will cause dup reports with crier component, so disable it.

<!-- Thank you for contributing -->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:
