### PR TITLE
chore(prow/jobs/pingcap/tidb): add two merged-tests to postsubmits

### DIFF
--- a/prow/jobs/pingcap/tidb/tidb-postsubmits.yaml
+++ b/prow/jobs/pingcap/tidb/tidb-postsubmits.yaml
@@ -49,3 +49,17 @@ postsubmits:
       skip_report: true
       branches:
         - ^master$
+    - name: pingcap/tidb/merged_integration_copr_test
+      agent: jenkins
+      decorate: false # need add this.
+      context: wip-integration-copr-test
+      skip_report: true
+      branches:
+        - ^master$
+    - name: pingcap/tidb/merged_tiflash_test
+      agent: jenkins
+      decorate: false # need add this.
+      context: wip-tiflash-test
+      skip_report: true
+      branches:
+        - ^master$


### PR DESCRIPTION
enable tow postsubmit jobs for pingcap/tidb:
* merged_integration_copr_test
* merged_tiflash_test