### PR TITLE
chore(pingcap/tidb): disable status report for unstable mergedci

### DIFF
--- a/prow/jobs/pingcap/tidb/tidb-postsubmits.yaml
+++ b/prow/jobs/pingcap/tidb/tidb-postsubmits.yaml
@@ -4,7 +4,7 @@ postsubmits:
       agent: jenkins
       decorate: false # need add this.
       context: ci/e2e-test
-      skip_report: false
+      skip_report: true
       branches:
         - ^master$
     - name: pingcap/tidb/merged_common_test
@@ -46,14 +46,14 @@ postsubmits:
       agent: jenkins
       decorate: false # need add this.
       context: ci/sqllogic-test
-      skip_report: false
+      skip_report: true
       branches:
         - ^master$
     - name: pingcap/tidb/merged_integration_copr_test
       agent: jenkins
       decorate: false # need add this.
       context: ci/integration-copr-test
-      skip_report: false
+      skip_report: true
       branches:
         - ^master$
     - name: pingcap/tidb/merged_tiflash_test


### PR DESCRIPTION
The following pipelines has a success rate of less than 90% in the last three days, disable the reporting, and wait for the repair pr finished.
* merged_e2e_test
* merged_integration_copr_test
* merged_sqllogic_test