### PR TITLE
fix(prow/cluster): bump tide images to support `replace` in template

### DIFF
--- a/prow/cluster/jenkins-operator-deployment.yaml
+++ b/prow/cluster/jenkins-operator-deployment.yaml
@@ -28,7 +28,7 @@ spec:
           image: ticommunityinfra/jenkins-operator:v20221227-9bc8171e1d
           args:
             - --dry-run=false
-            - --skip-report=false
+            - --skip-report=true # avoid dup reporting with crier component and reduce consuming of github api
             - --csrf-protect=false
             - --github-token-path=/etc/github/token
             - --config-path=/etc/config/config.yaml

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: "tide"
       containers:
         - name: tide
-          image: ticommunityinfra/tide:v20221207-9225e3a153
+          image: ticommunityinfra/tide:v20221227-9bc8171e1d
           args:
             - --dry-run=false
             - --config-path=/etc/config/config.yaml

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -36,13 +36,13 @@ ti-community-lgtm:
       - chaos-mesh/chaos-mesh
       - chaos-mesh/website
       - chaos-mesh/chaosd
-    pull_owners_endpoint: https://prow.tidb.net/ti-community-owners
+    pull_owners_endpoint: http://ti-community-owners.prow.svc/ti-community-owners
   - repos:
       - pingcap/docs
       - pingcap/docs-cn
       - pingcap/docs-dm
       - pingcap/docs-tidb-operator
-    pull_owners_endpoint: https://prow.tidb.net/ti-community-owners
+    pull_owners_endpoint: http://ti-community-owners.prow.svc/ti-community-owners
     ignore_invalid_review_prompt: true
 
 ti-community-merge:
@@ -84,7 +84,7 @@ ti-community-merge:
       - chaos-mesh/website
       - chaos-mesh/chaosd
     store_tree_hash: true
-    pull_owners_endpoint: https://prow.tidb.net/ti-community-owners
+    pull_owners_endpoint: http://ti-community-owners.prow.svc/ti-community-owners
 
 ti-community-owners:
   - repos:
@@ -1338,7 +1338,7 @@ ti-community-blunderbuss:
       - ti-community-infra/rfcs
       - ti-community-infra/devstats
       - ti-community-infra/devstats-dev-guide
-    pull_owners_endpoint: https://prow.tidb.net/ti-community-owners
+    pull_owners_endpoint: http://ti-community-owners.prow.svc/ti-community-owners
     max_request_count: 2
     exclude_reviewers:
       # Inactive maintainers
@@ -1351,7 +1351,7 @@ ti-community-blunderbuss:
       - mini-bot-2
   - repos:
       - tikv/pd
-    pull_owners_endpoint: https://prow.tidb.net/ti-community-owners
+    pull_owners_endpoint: http://ti-community-owners.prow.svc/ti-community-owners
     max_request_count: 2
     include_reviewers:
       # Tech Leaders
@@ -1365,7 +1365,7 @@ ti-community-blunderbuss:
       - JmPotato
   - repos:
       - pingcap/tidb-operator
-    pull_owners_endpoint: https://prow.tidb.net/ti-community-owners
+    pull_owners_endpoint: http://ti-community-owners.prow.svc/ti-community-owners
     max_request_count: 2
     include_reviewers:
       - DanielZhangQD
@@ -1376,7 +1376,7 @@ ti-community-blunderbuss:
       - better0332
   - repos:
       - pingcap/tiup
-    pull_owners_endpoint: https://prow.tidb.net/ti-community-owners
+    pull_owners_endpoint: http://ti-community-owners.prow.svc/ti-community-owners
     max_request_count: 2
     exclude_reviewers:
       # Bots
@@ -1391,7 +1391,7 @@ ti-community-blunderbuss:
   - repos:
       - pingcap/community
       - tikv/community
-    pull_owners_endpoint: https://prow.tidb.net/ti-community-owners
+    pull_owners_endpoint: http://ti-community-owners.prow.svc/ti-community-owners
     max_request_count: 2
     exclude_reviewers:
       # Bots
@@ -1400,7 +1400,7 @@ ti-community-blunderbuss:
     require_sig_label: true
   - repos:
       - pingcap/dumpling
-    pull_owners_endpoint: https://prow.tidb.net/ti-community-owners
+    pull_owners_endpoint: http://ti-community-owners.prow.svc/ti-community-owners
     max_request_count: 2
     include_reviewers:
       - lance6716
@@ -1408,7 +1408,7 @@ ti-community-blunderbuss:
       - kennytm
   - repos:
       - pingcap/dm
-    pull_owners_endpoint: https://prow.tidb.net/ti-community-owners
+    pull_owners_endpoint: http://ti-community-owners.prow.svc/ti-community-owners
     max_request_count: 2
     include_reviewers:
       - Ehco1996
@@ -1418,7 +1418,7 @@ ti-community-blunderbuss:
       - lichunzhu
   - repos:
       - pingcap/tidb-tools
-    pull_owners_endpoint: https://prow.tidb.net/ti-community-owners
+    pull_owners_endpoint: http://ti-community-owners.prow.svc/ti-community-owners
     max_request_count: 2
     include_reviewers:
       - glorv
@@ -1433,7 +1433,7 @@ ti-community-blunderbuss:
       - Little-Wallace
   - repos:
       - pingcap/br
-    pull_owners_endpoint: https://prow.tidb.net/ti-community-owners
+    pull_owners_endpoint: http://ti-community-owners.prow.svc/ti-community-owners
     max_request_count: 2
     include_reviewers:
       - glorv
@@ -1447,7 +1447,7 @@ ti-community-blunderbuss:
       - Leavrth
   - repos:
       - chaos-mesh/chaos-mesh
-    pull_owners_endpoint: https://prow.tidb.net/ti-community-owners
+    pull_owners_endpoint: http://ti-community-owners.prow.svc/ti-community-owners
     max_request_count: 2
     include_reviewers:
       - cwen0
@@ -1469,7 +1469,7 @@ ti-community-blunderbuss:
       - xlgao-zju
   - repos:
       - chaos-mesh/chaosd
-    pull_owners_endpoint: https://prow.tidb.net/ti-community-owners
+    pull_owners_endpoint: http://ti-community-owners.prow.svc/ti-community-owners
     max_request_count: 2
     include_reviewers:
       - cwen0
@@ -1491,7 +1491,7 @@ ti-community-blunderbuss:
       - xlgao-zju
   - repos:
       - pingcap/docs
-    pull_owners_endpoint: https://prow.tidb.net/ti-community-owners
+    pull_owners_endpoint: http://ti-community-owners.prow.svc/ti-community-owners
     max_request_count: 1
     include_reviewers:
       - shichun-0415
@@ -1502,7 +1502,7 @@ ti-community-blunderbuss:
       - hfxsd
   - repos:
       - pingcap/docs-cn
-    pull_owners_endpoint: https://prow.tidb.net/ti-community-owners
+    pull_owners_endpoint: http://ti-community-owners.prow.svc/ti-community-owners
     max_request_count: 1
     include_reviewers:
       - shichun-0415
@@ -1513,13 +1513,13 @@ ti-community-blunderbuss:
       - hfxsd
   - repos:
       - pingcap/docs-dm
-    pull_owners_endpoint: https://prow.tidb.net/ti-community-owners
+    pull_owners_endpoint: http://ti-community-owners.prow.svc/ti-community-owners
     max_request_count: 1
     include_reviewers:
       - ran-huang
   - repos:
       - pingcap/docs-tidb-operator
-    pull_owners_endpoint: https://prow.tidb.net/ti-community-owners
+    pull_owners_endpoint: http://ti-community-owners.prow.svc/ti-community-owners
     max_request_count: 1
     include_reviewers:
       - ran-huang


### PR DESCRIPTION
<!-- Thank you for contributing -->

### What problem does this PR solve?

Bump tide image and reduce GitHub api consuming in `jenkins-operator` component.

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:
