### PR TITLE
fix(prow/cluster): set first github graphql endpoint to ghproxy svc

### DIFF
--- a/prow/cluster/ti_community_autoresponder_deployment.yaml
+++ b/prow/cluster/ti_community_autoresponder_deployment.yaml
@@ -26,6 +26,8 @@ spec:
             - --github-token-path=/etc/github/token
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
+            - --github-graphql-endpoint=http://ghproxy/graphql
+            - --github-graphql-endpoint=https://api.github.com/graphql
           ports:
             - name: http
               containerPort: 80

--- a/prow/cluster/ti_community_blunderbuss_deployment.yaml
+++ b/prow/cluster/ti_community_blunderbuss_deployment.yaml
@@ -26,6 +26,8 @@ spec:
             - --github-token-path=/etc/github/token
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
+            - --github-graphql-endpoint=http://ghproxy/graphql
+            - --github-graphql-endpoint=https://api.github.com/graphql
           ports:
             - name: http
               containerPort: 80

--- a/prow/cluster/ti_community_cherrypicker_deployment.yaml
+++ b/prow/cluster/ti_community_cherrypicker_deployment.yaml
@@ -25,6 +25,8 @@ spec:
             - --github-token-path=/etc/github/token
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
+            - --github-graphql-endpoint=http://ghproxy/graphql
+            - --github-graphql-endpoint=https://api.github.com/graphql
           ports:
             - name: http
               containerPort: 80

--- a/prow/cluster/ti_community_contribution_deployment.yaml
+++ b/prow/cluster/ti_community_contribution_deployment.yaml
@@ -26,6 +26,8 @@ spec:
             - --github-token-path=/etc/github/token
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
+            - --github-graphql-endpoint=http://ghproxy/graphql
+            - --github-graphql-endpoint=https://api.github.com/graphql
           ports:
             - name: http
               containerPort: 80

--- a/prow/cluster/ti_community_format_checker_deployment.yaml
+++ b/prow/cluster/ti_community_format_checker_deployment.yaml
@@ -26,6 +26,8 @@ spec:
             - --github-token-path=/etc/github/token
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
+            - --github-graphql-endpoint=http://ghproxy/graphql
+            - --github-graphql-endpoint=https://api.github.com/graphql
           ports:
             - name: http
               containerPort: 80

--- a/prow/cluster/ti_community_issue_triage_deployment.yaml
+++ b/prow/cluster/ti_community_issue_triage_deployment.yaml
@@ -26,6 +26,8 @@ spec:
             - --github-token-path=/etc/github/token
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
+            - --github-graphql-endpoint=http://ghproxy/graphql
+            - --github-graphql-endpoint=https://api.github.com/graphql
           ports:
             - name: http
               containerPort: 80

--- a/prow/cluster/ti_community_label_blocker_deployment.yaml
+++ b/prow/cluster/ti_community_label_blocker_deployment.yaml
@@ -26,6 +26,8 @@ spec:
             - --github-token-path=/etc/github/token
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
+            - --github-graphql-endpoint=http://ghproxy/graphql
+            - --github-graphql-endpoint=https://api.github.com/graphql
           ports:
             - name: http
               containerPort: 80

--- a/prow/cluster/ti_community_label_deployment.yaml
+++ b/prow/cluster/ti_community_label_deployment.yaml
@@ -26,6 +26,8 @@ spec:
             - --github-token-path=/etc/github/token
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
+            - --github-graphql-endpoint=http://ghproxy/graphql
+            - --github-graphql-endpoint=https://api.github.com/graphql
           ports:
             - name: http
               containerPort: 80

--- a/prow/cluster/ti_community_lgtm_deployment.yaml
+++ b/prow/cluster/ti_community_lgtm_deployment.yaml
@@ -26,6 +26,8 @@ spec:
             - --github-token-path=/etc/github/token
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
+            - --github-graphql-endpoint=http://ghproxy/graphql
+            - --github-graphql-endpoint=https://api.github.com/graphql
           ports:
             - name: http
               containerPort: 80

--- a/prow/cluster/ti_community_merge_deployment.yaml
+++ b/prow/cluster/ti_community_merge_deployment.yaml
@@ -26,6 +26,8 @@ spec:
             - --github-token-path=/etc/github/token
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
+            - --github-graphql-endpoint=http://ghproxy/graphql
+            - --github-graphql-endpoint=https://api.github.com/graphql
           ports:
             - name: http
               containerPort: 80

--- a/prow/cluster/ti_community_owners_deployment.yaml
+++ b/prow/cluster/ti_community_owners_deployment.yaml
@@ -26,6 +26,8 @@ spec:
             - --github-token-path=/etc/github/token
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
+            - --github-graphql-endpoint=http://ghproxy/graphql
+            - --github-graphql-endpoint=https://api.github.com/graphql
           ports:
             - name: http
               containerPort: 80

--- a/prow/cluster/ti_community_tars_deployment.yaml
+++ b/prow/cluster/ti_community_tars_deployment.yaml
@@ -26,6 +26,8 @@ spec:
             - --github-token-path=/etc/github/token
             - --github-endpoint=http://ghproxy
             - --github-endpoint=https://api.github.com
+            - --github-graphql-endpoint=http://ghproxy/graphql
+            - --github-graphql-endpoint=https://api.github.com/graphql
           ports:
             - name: http
               containerPort: 80


### PR DESCRIPTION
try to avoid graphql api quota be throttled


<!-- Thank you for contributing -->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:
