### PR TITLE
chore(pingcap/tidb): remove tidb required check

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -549,7 +549,6 @@ branch-protection:
                   - "idc-jenkins-ci-tidb/mysql-test"
                   - "license/cla"
                   - "check-issue-triage-complete"
-                  - "check"
                   - "tide"
                 strict: true
             release-2.1:


### PR DESCRIPTION
remove this reuqired status: license check has been migrated from github action to ksyun jenkins (idc-jenkins-ci-tidb/check_dev)