### PR TITLE
chore(pingcap/tiflash): remove tiflash required context `check-license` in branch protect rules

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1779,7 +1779,6 @@ branch-protection:
                   - "idc-jenkins-ci-tiflash/build"
                   - "check-issue-triage-complete"
                   - "license/cla"
-                  - "check-license"
                 strict: true
             release-4.0:
               protect: true


### PR DESCRIPTION
Already migrated the GitHub action workflow into other pipelines.

Ref: https://github.com/PingCAP-QE/ci/pull/1722
