### PR TITLE
fix(prow/config): remove `config-updater` plugin on repos for GitOps

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -170,7 +170,6 @@ plugins:
     - assign
     - blunderbuss
     - branchcleaner
-    - config-updater
     - heart
     - help
     - hold
@@ -393,7 +392,6 @@ plugins:
     - assign
     - blunderbuss
     - cat
-    - config-updater
     - dog
     - heart
     - help


### PR DESCRIPTION
Why:

For the initialization, we need manually create the config map to boot the prow instance, it's not automatic.
Currently we have migrate to GitOps powered by fluxcd tool, we should remove it to avoid conflicts with GitOps.

What's Changed:

change plugins list on repos: 
- ti-community-infra/configs
- pingcap-qe/ci



