### PR TITLE
config(prow/config): migrate to `lgtm` + `approve` plugins  for tiunimanager repos

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -2863,8 +2863,6 @@ tide:
         - pingcap/tidb-dashboard
         - pingcap/tidb-operator
         - pingcap/tispark
-        - pingcap/tiunimanager
-        - pingcap/tiunimanager-ui
         - pingcap/tiup
         - tikv/community
       labels:
@@ -3032,17 +3030,19 @@ tide:
 
     # Repos which migrated to lgtm + approve plugins
     - repos:
-        - PingCAP-QE/ci
-        - ti-community-infra/configs
+        - pingcap-inc/enterprise-extensions
         - PingCAP-QE/automated-tests
         - PingCAP-QE/benchbot
+        - PingCAP-QE/ci
         - PingCAP-QE/endless
         - PingCAP-QE/qa
         - PingCAP-QE/test-infra
         - PingCAP-QE/test-plan
         - PingCAP-QE/workload
         - pingcap/tidb-test
-        - pingcap-inc/enterprise-extensions
+        - pingcap/tiunimanager
+        - pingcap/tiunimanager-ui        
+        - ti-community-infra/configs
       labels:
         - lgtm
         - approved

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -18,8 +18,6 @@ ti-community-lgtm:
       - pingcap/tiflash
       - pingcap/tiflow
       - pingcap/tispark
-      - pingcap/tiunimanager
-      - pingcap/tiunimanager-ui
       - pingcap/tiup
       - tikv/community
       - tikv/pd
@@ -51,8 +49,6 @@ ti-community-merge:
       - pingcap/tiflash
       - pingcap/tiflow
       - pingcap/tispark
-      - pingcap/tiunimanager
-      - pingcap/tiunimanager-ui
       - pingcap/tiup
       - tikv/community
       - tikv/pd
@@ -383,28 +379,6 @@ ti-community-owners:
       - bigdata-committers
     reviewer_teams:
       - bigdata-reviewers
-    sig_endpoint: https://bots.tidb.io/ti-community-bot
-    require_lgtm_label_prefix: require-LGT
-  - repos:
-      - pingcap/tiunimanager
-    default_require_lgtm: 2
-    use_github_team: true
-    committer_teams:
-      - tiunimanager-maintainers
-      - tiunimanager-committers
-    reviewer_teams:
-      - tiunimanager-reviewers
-    sig_endpoint: https://bots.tidb.io/ti-community-bot
-    require_lgtm_label_prefix: require-LGT
-  - repos:
-      - pingcap/tiunimanager-ui
-    default_require_lgtm: 1
-    use_github_team: true
-    committer_teams:
-      - tiunimanager-maintainers
-      - tiunimanager-committers
-    reviewer_teams:
-      - tiunimanager-reviewers
     sig_endpoint: https://bots.tidb.io/ti-community-bot
     require_lgtm_label_prefix: require-LGT
   - repos:

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -304,19 +304,31 @@ plugins:
     - wip
     - lifecycle
   pingcap/tiunimanager:
-    - welcome
+    - approve
     - assign
+    - blunderbuss
     - hold
-    - wip
-    - size
+    - lgtm
     - lifecycle
+    - owners-label
+    - size
+    - trigger
+    - verify-owners
+    - welcome
+    - wip
   pingcap/tiunimanager-ui:
-    - welcome
+    - approve
     - assign
+    - blunderbuss
     - hold
-    - wip
-    - size
+    - lgtm
     - lifecycle
+    - owners-label
+    - size
+    - trigger    
+    - verify-owners
+    - welcome
+    - wip
   pingcap/tidb-test:
     - approve
     - assign
@@ -1168,17 +1180,6 @@ external_plugins:
       events:
         - pull_request
   pingcap/tiunimanager:
-    - name: ti-community-lgtm
-      endpoint: http://prow-ti-community-lgtm
-      events:
-        - pull_request_review
-        - pull_request
-    - name: ti-community-merge
-      endpoint: http://prow-ti-community-merge
-      events:
-        - issue_comment
-        - pull_request_review_comment
-        - pull_request
     - name: needs-rebase
       endpoint: http://prow-needs-rebase
       events:
@@ -1199,17 +1200,6 @@ external_plugins:
       events:
         - pull_request
   pingcap/tiunimanager-ui:
-    - name: ti-community-lgtm
-      endpoint: http://prow-ti-community-lgtm
-      events:
-        - pull_request_review
-        - pull_request
-    - name: ti-community-merge
-      endpoint: http://prow-ti-community-merge
-      events:
-        - issue_comment
-        - pull_request_review_comment
-        - pull_request
     - name: needs-rebase
       endpoint: http://prow-needs-rebase
       events:


### PR DESCRIPTION
### What problem does this PR solve?

update bot config for `tiunimanager` and `tiunimanager-ui` repos to migrage review plugins.

Issue Number: ref pingcap/tiunimanager-ui#195

Ref: https://github.com/ti-community-infra/configs/issues/824
