### PR TITLE
config(prow/config): turn off PR events to `chatgpt` plugin on `pingcap-qe/test-infra` repo

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -1563,7 +1563,7 @@ external_plugins:
   PingCAP-QE/test-infra:
     - name: chatgpt
       endpoint: http://prow-chatgpt
-      events: [issue_comment, pull_request]
+      events: [issue_comment]
     - name: needs-rebase
       endpoint: http://prow-needs-rebase
       events: [issue_comment, pull_request]


### PR DESCRIPTION
## Why
The repo owner want to disable automatic reviewing of the `chatgpt` plugin, he want request it manually.