### PR TITLE
config(prow/config): remove plugin blunderbuss for `pingcap/tiflash` repo

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -396,7 +396,6 @@ plugins:
   pingcap/tiflash:
     - approve
     - assign
-    - blunderbuss
     - cherry-pick-unapproved
     - hold
     - lgtm


### PR DESCRIPTION
As title, currently many reviewers are inactive, we need manually request reviewers.