### PR TITLE
config(prow/config): remove plugin blunderbuss for `pingcap/tiflow` repo

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -364,7 +364,6 @@ plugins:
   pingcap/tiflow:
     - approve
     - assign
-    - blunderbuss
     - cherry-pick-unapproved
     - hold
     - lgtm


### PR DESCRIPTION
As title, currently many reviewers are inactive, we need manually request reviewers.
