### PR TITLE
config(prow/config): remove plugin blunderbuss for `pingcap/tidb` repo

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -290,7 +290,6 @@ plugins:
   pingcap/tidb:
     - approve
     - assign
-    - blunderbuss
     - cherry-pick-unapproved
     - hold
     - lgtm


### PR DESCRIPTION
As title, currently many reviewers are inactive, we need manually request reviewers.