### PR TITLE
config(prow/config): update the tars required PR label from `approved` to `lgtm`

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -621,7 +621,7 @@ ti-community-tars:
       - pingcap-inc/tiflash-scripts
       - pingcap/tidb-binlog
       - pingcap/tispark
-    only_when_label: "approved"
+    only_when_label: "lgtm"
     exclude_labels:
       - needs-rebase
       - do-not-merge/hold


### PR DESCRIPTION
`Tars` plugin can only set one label to be required, so we can not set `lgtm` + `approved` for it without modify the plugin.
Currently tiflash need 2 lgtm votes to make the PR `lgtm`ed, so `lgtm` label should be better.


We planed to refactor CI jobs for tiflash repo next month, we do not need tars plugin to refresh PRs when jobs are  refactored. 