### PR TITLE
config(tiflow): remove some required status on tiflow

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1597,6 +1597,10 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
+                  - "idc-jenkins-ci-ticdc/integration-test"
+                  - "idc-jenkins-ci-ticdc/kafka-integration-test"
+                  - "idc-jenkins-ci-ticdc/dm-integration-test"
+                  - "idc-jenkins-ci-ticdc/dm-compatibility-test"
                   - "jenkins-ticdc/verify"
                   - "license/cla"
                   - "tide"
@@ -1608,11 +1612,15 @@ branch-protection:
                   - "jenkins-ticdc/verify"
                   - "license/cla"
                   - "tide"
-                strict: true
+                strict: false
             release-6.2:
               protect: true
               required_status_checks:
                 contexts:
+                  - "idc-jenkins-ci-ticdc/integration-test"
+                  - "idc-jenkins-ci-ticdc/kafka-integration-test"
+                  - "idc-jenkins-ci-ticdc/dm-integration-test"
+                  - "idc-jenkins-ci-ticdc/dm-compatibility-test"
                   - "jenkins-ticdc/verify"
                   - "license/cla"
                   - "tide"
@@ -1621,6 +1629,10 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
+                  - "idc-jenkins-ci-ticdc/integration-test"
+                  - "idc-jenkins-ci-ticdc/kafka-integration-test"
+                  - "idc-jenkins-ci-ticdc/dm-integration-test"
+                  - "idc-jenkins-ci-ticdc/dm-compatibility-test"
                   - "jenkins-ticdc/verify"
                   - "license/cla"
                   - "tide"
@@ -1629,6 +1641,10 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
+                  - "idc-jenkins-ci-ticdc/integration-test"
+                  - "idc-jenkins-ci-ticdc/kafka-integration-test"
+                  - "idc-jenkins-ci-ticdc/dm-integration-test"
+                  - "idc-jenkins-ci-ticdc/dm-compatibility-test"
                   - "jenkins-ticdc/verify"
                   - "license/cla"
                   - "tide"
@@ -1640,11 +1656,15 @@ branch-protection:
                   - "jenkins-ticdc/verify"
                   - "license/cla"
                   - "tide"
-                strict: true
+                strict: false
             release-6.6:
               protect: true
               required_status_checks:
                 contexts:
+                  - "idc-jenkins-ci-ticdc/integration-test"
+                  - "idc-jenkins-ci-ticdc/kafka-integration-test"
+                  - "idc-jenkins-ci-ticdc/dm-integration-test"
+                  - "idc-jenkins-ci-ticdc/dm-compatibility-test"
                   - "jenkins-ticdc/verify"
                   - "license/cla"
                   - "tide"
@@ -1653,6 +1673,10 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
+                  - "idc-jenkins-ci-ticdc/integration-test"
+                  - "idc-jenkins-ci-ticdc/kafka-integration-test"
+                  - "idc-jenkins-ci-ticdc/dm-integration-test"
+                  - "idc-jenkins-ci-ticdc/dm-compatibility-test"
                   - "jenkins-ticdc/verify"
                   - "license/cla"
                   - "tide"

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1597,10 +1597,6 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
-                  - "idc-jenkins-ci-ticdc/integration-test"
-                  - "idc-jenkins-ci-ticdc/kafka-integration-test"
-                  - "idc-jenkins-ci-ticdc/dm-integration-test"
-                  - "idc-jenkins-ci-ticdc/dm-compatibility-test"
                   - "jenkins-ticdc/verify"
                   - "license/cla"
                   - "tide"
@@ -1609,10 +1605,6 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
-                  - "idc-jenkins-ci-ticdc/integration-test"
-                  - "idc-jenkins-ci-ticdc/kafka-integration-test"
-                  - "idc-jenkins-ci-ticdc/dm-integration-test"
-                  - "idc-jenkins-ci-ticdc/dm-compatibility-test"
                   - "jenkins-ticdc/verify"
                   - "license/cla"
                   - "tide"
@@ -1621,10 +1613,6 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
-                  - "idc-jenkins-ci-ticdc/integration-test"
-                  - "idc-jenkins-ci-ticdc/kafka-integration-test"
-                  - "idc-jenkins-ci-ticdc/dm-integration-test"
-                  - "idc-jenkins-ci-ticdc/dm-compatibility-test"
                   - "jenkins-ticdc/verify"
                   - "license/cla"
                   - "tide"
@@ -1633,10 +1621,6 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
-                  - "idc-jenkins-ci-ticdc/integration-test"
-                  - "idc-jenkins-ci-ticdc/kafka-integration-test"
-                  - "idc-jenkins-ci-ticdc/dm-integration-test"
-                  - "idc-jenkins-ci-ticdc/dm-compatibility-test"
                   - "jenkins-ticdc/verify"
                   - "license/cla"
                   - "tide"
@@ -1645,10 +1629,6 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
-                  - "idc-jenkins-ci-ticdc/integration-test"
-                  - "idc-jenkins-ci-ticdc/kafka-integration-test"
-                  - "idc-jenkins-ci-ticdc/dm-integration-test"
-                  - "idc-jenkins-ci-ticdc/dm-compatibility-test"
                   - "jenkins-ticdc/verify"
                   - "license/cla"
                   - "tide"
@@ -1657,10 +1637,6 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
-                  - "idc-jenkins-ci-ticdc/integration-test"
-                  - "idc-jenkins-ci-ticdc/kafka-integration-test"
-                  - "idc-jenkins-ci-ticdc/dm-integration-test"
-                  - "idc-jenkins-ci-ticdc/dm-compatibility-test"
                   - "jenkins-ticdc/verify"
                   - "license/cla"
                   - "tide"
@@ -1669,10 +1645,6 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
-                  - "idc-jenkins-ci-ticdc/integration-test"
-                  - "idc-jenkins-ci-ticdc/kafka-integration-test"
-                  - "idc-jenkins-ci-ticdc/dm-integration-test"
-                  - "idc-jenkins-ci-ticdc/dm-compatibility-test"
                   - "jenkins-ticdc/verify"
                   - "license/cla"
                   - "tide"
@@ -1681,10 +1653,6 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
-                  - "idc-jenkins-ci-ticdc/integration-test"
-                  - "idc-jenkins-ci-ticdc/kafka-integration-test"
-                  - "idc-jenkins-ci-ticdc/dm-integration-test"
-                  - "idc-jenkins-ci-ticdc/dm-compatibility-test"
                   - "jenkins-ticdc/verify"
                   - "license/cla"
                   - "tide"


### PR DESCRIPTION
Remove some required status on tiflow release-6.1 and release-6.5. 
Integration testing pipelines does not automatically trigger every push commit, we have set run_before_merged in prow presubmit config to ensure those pipeline passed before pr merged.