### PR TITLE
config(tiflow): remove some required check because prow trigger

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1572,10 +1572,6 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
-                  - "idc-jenkins-ci-ticdc/integration-test"
-                  - "idc-jenkins-ci-ticdc/kafka-integration-test"
-                  - "idc-jenkins-ci-ticdc/dm-integration-test"
-                  - "idc-jenkins-ci-ticdc/dm-compatibility-test"
                   - "idc-jenkins-ci-ticdc/unit-test"
                   - "idc-jenkins-ci/leak-test"
                   - "license/cla"
@@ -1585,10 +1581,6 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
-                  - "idc-jenkins-ci-ticdc/integration-test"
-                  - "idc-jenkins-ci-ticdc/kafka-integration-test"
-                  - "idc-jenkins-ci-ticdc/dm-integration-test"
-                  - "idc-jenkins-ci-ticdc/dm-compatibility-test"
                   - "jenkins-ticdc/verify"
                   - "license/cla"
                   - "tide"

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1576,7 +1576,7 @@ branch-protection:
                   - "idc-jenkins-ci/leak-test"
                   - "license/cla"
                   - "tide"
-                strict: true
+                strict: false
             release-5.4:
               protect: true
               required_status_checks:
@@ -1584,7 +1584,7 @@ branch-protection:
                   - "jenkins-ticdc/verify"
                   - "license/cla"
                   - "tide"
-                strict: true
+                strict: false
             release-6.0:
               protect: true
               required_status_checks:

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -621,7 +621,7 @@ ti-community-tars:
       - pingcap-inc/tiflash-scripts
       - pingcap/tidb-binlog
       - pingcap/tispark
-    only_when_label: "approved"
+    only_when_label: "lgtm"
     exclude_labels:
       - needs-rebase
       - do-not-merge/hold


### PR DESCRIPTION
Remove some required status on tiflow release-5.3 and release-5.4.

Integration testing pipelines does not automatically trigger every push commit, we have set run_before_merged in prow presubmit config to ensure those pipeline passed before pr merged.