### PR TITLE
config(pingcap/docs*): allow add `lgtm` label by document team on pull requests

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -708,10 +708,42 @@ ti-community-tars:
 
 ti-community-label-blocker:
   - repos:
-      - pingcap-inc/tiflash-scripts
       - pingcap/docs
       - pingcap/docs-cn
       - pingcap/docs-tidb-operator
+    block_labels:
+      - regex: ^(lgtm)$
+        actions:
+          - labeled
+          - unlabeled
+        trusted_users:
+          - ti-chi-bot
+          - ti-chi-bot[bot]   
+          # document team:
+          - lilin90
+          - qiancai
+          - ran-hang
+          - Oreoxmt
+          - hfxsd           
+      - regex: ^(approved|needs-[0-9]+-more-lgtm)$
+        actions:
+          - labeled
+          - unlabeled
+        trusted_users:
+          - ti-chi-bot
+          - ti-chi-bot[bot]
+      - regex: "^cherry-pick-approved$"
+        actions:
+          - labeled
+          - unlabeled
+        trusted_teams:
+          - qa-release-merge
+        trusted_users:
+          - ti-chi-bot
+          - ti-chi-bot[bot]
+  
+  - repos:
+      - pingcap-inc/tiflash-scripts
       - pingcap/tidb
       - pingcap/tidb-binlog
       - pingcap/tidb-tools


### PR DESCRIPTION
Update congfiguration of external plugin `ti-community-label-blocker`.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>

<!-- Thank you for contributing -->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:
