### PR TITLE
chore(prow/config): delete prow job contexts in branch protection for tidb@master

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -656,11 +656,6 @@ branch-protection:
                 required_approving_review_count: 1
               required_status_checks:
                 contexts:
-                  - "idc-jenkins-ci-tidb/build"
-                  - "idc-jenkins-ci-tidb/check_dev"
-                  - "idc-jenkins-ci-tidb/check_dev_2"
-                  - "idc-jenkins-ci-tidb/unit-test"
-                  - "idc-jenkins-ci-tidb/mysql-test"
                   - "license/cla"
                   - "check-issue-triage-complete"
                   - "tide"


### PR DESCRIPTION
No need explicit contexts for prow jobs.

Ref: https://docs.prow.k8s.io/docs/components/core/tide/config/#context-policy-options

We only need to ensure tide in required contexts.

Ref:
- https://github.com/PingCAP-QE/ci/issues/2129
- #812 (reverted before)