### PR TITLE
config: allow merging pr to release-1.x in docs-tidb-operator

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -2595,6 +2595,7 @@ tide:
       # github query api index with `HasPrefix`.
       includedBranches:
         - master # trunk branch.
+        - release-1. # release-1.2 ~ release-1.5 for docs-tidb-operator
         - release-3.
         - release-4.
         - release-5.


### PR DESCRIPTION
https://github.com/pingcap/docs-tidb-operator/pull/2388 cannot be merged under the current config.