### PR TITLE
config(prow/config): reduce tide query interval from 120s to 90s

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -2294,7 +2294,7 @@ plank:
         sidecar: gcr.io/k8s-prow/sidecar:v20230601-43eb1068e4
 
 tide:
-  sync_period: 2m
+  sync_period: 1m30s
 
   merge_method:
     pingcap-inc/enterprise-extensions: squash


### PR DESCRIPTION
For fast feedback