### PR TITLE
config(prow/config): migrate openai config from pingcap-qe/ee-ops repo

### DIFF
--- a/prow/config/kustomization.yaml
+++ b/prow/config/kustomization.yaml
@@ -43,4 +43,9 @@ configMapGenerator:
       disableNameSuffixHash: true
     files:
       - external_plugins_config.yaml
-
+  - name: prow-openai
+    namespace: apps
+    options:
+      disableNameSuffixHash: true
+    files:
+      - openai/tasks.yaml

--- a/prow/config/openai/tasks.yaml
+++ b/prow/config/openai/tasks.yaml
@@ -1,0 +1,41 @@
+---
+# ORG:
+# ---- or ---
+# ORG/repo:
+PingCAP-QE/test-infra:
+  default:
+    name: review summary
+    system_message: |
+      You are an experienced software developer. You will act as a reviewer for a GitHub Pull Request, and you should answer by markdown format.
+    user_prompt: |
+      Please help me to review the github pull request: summarize the key changes and identify potential problems, then give some fixing suggestions.
+    patch_introduce_prompt: |
+      This is the diff for the pull request:
+    output_static_head_note: |-
+      > **I have already done a preliminary review for you, and I hope to help you do a better job.**
+    external_contexts: []
+      # - prompt_tpl: |
+      #     This the context about context A: %s
+      #   res_url: https://external.site/resource.html
+pingcap/docs: &docs
+  default: # default task profile, you can trigger it with `/review default`
+    name: default review summary
+    system_message: >
+      You are a senior technical writer. You will act as a reviewer for a GitHub Pull Request, and you should answer in markdown format.
+    user_prompt: |
+      1. Evaluate the title, description, and diff of the PR. If the title is unclear, suggest a concise and appropriate alternative that summarizes the changes made in the diff.
+      2. Review the diff thoroughly and provide suggestions to improve its clarity, conciseness, and correctness.
+    patch_introduce_prompt: |
+      This is the diff for the pull request:
+    output_static_head_note: |-
+      > **I have already done a preliminary review for you, and I hope to help you do a better job.**
+    external_contexts: []
+    max_response_tokens: 2000 # keep it between 250 and 2000,larger max_response_tokens smaller request_playload_limit.
+    skip_authors: 
+      - ti-chi-bot
+      - ti-chi-bot[bot]
+    skip_label_regs:
+      - ^do-not-merge/
+
+pingcap/docs-cn: *docs
+pingcap/docs-tidb-operator: *docs


### PR DESCRIPTION
Why:
- `ee-ops` repo should not contain the config files that served for business logic, it's not for community.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>
