### PR TITLE
config(prow/config): forbid merge pull request to release-x.y.z of `tidb-test` repo

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -2452,7 +2452,6 @@ tide:
         - pingcap/tidb-binlog
         - pingcap/tidb-dashboard
         - pingcap/tidb-operator
-        - pingcap/tidb-test
         - pingcap/tidb-tools
         - pingcap/tiflash
         - pingcap/tiflow
@@ -2469,6 +2468,32 @@ tide:
         - release-6. # release-6.x.y, release-6.x.y-*
         - release-7.1 # LTS: avoid prow's "Merging to branch *** is forbidden" description issue.
         - release-7. # release-7.x.y, release-7.x.y-*
+      labels:
+        - lgtm
+        - approved
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/blocked-paths
+        - do-not-merge/cherry-pick-not-approved
+        - do-not-merge/contains-merge-commits
+        - do-not-merge/hold
+        - do-not-merge/invalid-commit-message
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/invalid-title
+        - do-not-merge/needs-linked-issue
+        - do-not-merge/needs-triage-completed
+        - do-not-merge/release-note-label-needed
+        - do-not-merge/work-in-progress
+        - needs-rebase
+
+    - repos:
+        - pingcap/tidb-test
+        # github query api index with `HasPrefix`.
+      excludedBranches:
+        # patched release branches.
+        - release-6.1.
+        - release-6.5.
+        - release-7.1.
       labels:
         - lgtm
         - approved


### PR DESCRIPTION
## Why

- if allow it, it may break other hotfix pull request on `mysql-test` job.

Ref:
- https://github.com/pingcap/tidb/pull/45088 `affected`

Fix: https://github.com/PingCAP-QE/ci/issues/2206