### PR TITLE
config(prow/config): update branch protection config for pingcap/tidb release-6.5

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -724,11 +724,6 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
-                  - "idc-jenkins-ci-tidb/build"
-                  - "idc-jenkins-ci-tidb/check_dev"
-                  - "idc-jenkins-ci-tidb/check_dev_2"
-                  - "idc-jenkins-ci-tidb/unit-test"
-                  - "idc-jenkins-ci-tidb/mysql-test"
                   - "license/cla"
                   - "tide"
                 strict: false


### PR DESCRIPTION
### What problem does this PR solve?
Issue Number: ref https://github.com/PingCAP-QE/ci/issues/2129

Problem Summary:

### What is changed and how it works?
What's Changed:

update branch protect rules for release-6.1

How it Works:

* Prepare to enable condition triggering on CI jobs for efficiency.
* Now the jobs will be triggered by prow bot, we just need to keep tide in required context list.
* The feature has enabled in trunk branch for serval weeks, It's stable and correct.
* when it merged we need update the hot fix branch protection (by regex) manually