### PR TITLE
chore(pingcap/tidb): disable github review approve and codeowner required options

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -615,9 +615,6 @@ branch-protection:
           branches:
             master:
               protect: true
-              required_pull_request_reviews:
-                require_code_owner_reviews: true
-                required_approving_review_count: 1
               required_status_checks:
                 contexts:
                   - "license/cla"


### PR DESCRIPTION
Disable the required options in branch protect rule for master branch.
Prepare for enable congfiguration owner approving mechanism.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>

<!-- Thank you for contributing -->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:
