### PR TITLE
fix(pingcap/community): disable cherry pick external plugin

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -701,11 +701,6 @@ external_plugins:
       events:
         - issue_comment
         - push
-    - name: ti-community-cherrypicker
-      endpoint: http://prow-ti-community-cherrypicker
-      events:
-        - pull_request
-        - issue_comment
   pingcap/tiup:
     - name: needs-rebase
       endpoint: http://prow-needs-rebase


### PR DESCRIPTION


### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

The plugin is enabled for `pingcap/community` but not configuration label prefix for it, and it will cause unexpected comments, such as:
<img width="913" alt="image" src="https://github.com/ti-community-infra/configs/assets/2574558/85978db9-e974-4d2a-ac73-1fcebffe7525">


### What is changed and how it works?

What's Changed:

Disable the plugin for `pingcap/community` repo. it's no need.

How it Works:
