### PR TITLE
chore(pingcap/tiup): update approve plugin config

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -15,6 +15,12 @@ approve:
     require_self_approval: true
     commandHelpLink: "https://prow.tidb.net/command-help"
     pr_process_link: "https://book.prow.tidb.net/#/workflows/pr"
+  - repos: [pingcap/tiup]
+    lgtm_acts_as_approve: false
+    ignore_review_state: true
+    require_self_approval: true
+    commandHelpLink: "https://prow.tidb.net/command-help"
+    pr_process_link: "https://book.prow.tidb.net/#/workflows/pr"    
 lgtm:
   - repos: [pingcap, PingCAP-QE, pingcap-inc]
     review_acts_as_lgtm: true


### PR DESCRIPTION
What's Changed:

- the approvers' PR need self approval.
- only approving by comment "/approve" by approvers.
