### PR TITLE
feat(pingcap/tidb): block mergeing for pull requests which have none finished test tasks

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -2398,6 +2398,7 @@ tide:
         - do-not-merge/invalid-owners-file
         - do-not-merge/invalid-title
         - do-not-merge/needs-linked-issue
+        - do-not-merge/needs-finished-tests
         - do-not-merge/needs-triage-completed
         - do-not-merge/release-note-label-needed
         - do-not-merge/work-in-progress

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -2398,7 +2398,7 @@ tide:
         - do-not-merge/invalid-owners-file
         - do-not-merge/invalid-title
         - do-not-merge/needs-linked-issue
-        - do-not-merge/needs-finished-tests
+        - do-not-merge/needs-tests-checked
         - do-not-merge/needs-triage-completed
         - do-not-merge/release-note-label-needed
         - do-not-merge/work-in-progress

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -931,6 +931,24 @@ ti-community-format-checker:
           <sub>:open_book: For more info, you can check the ["Contribute Code"](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#referring-to-an-issue) section in the development guide.</sub>
         missing_label: do-not-merge/needs-linked-issue
         skip_label: skip-issue-check
+      - pull_request: true
+        body: true
+        branches: [master]
+        regexp: "\\\\n\\\\bTests <!-- At least one of them must be included\\\\. -->\\\\s*[\\\\n]{1,}(- \\\\[[xX ]\\\\] .*\\\\n)*(- \\\\[[xX]\\\\] .*\\\\n)(- \\\\[[xX ]\\\\] .*\\\\n)*\\\\n"
+        missing_label: do-not-merge/needs-finished-tests
+        missing_message: |
+          **Notice**: To remove the `do-not-merge/needs-finished-tests` label, please finished the test for the pull request and check the finished items in description.
+
+          For example:
+
+          > Tests <!-- At least one of them must be included. -->
+          > 
+          > - [x] Unit test
+          > - [ ] Integration test
+          > - [ ] Manual test (add detailed scripts or steps below)
+          > - [ ] No code
+
+          <sub>:open_book: For more info, you can check the ["Contribute Code"](https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/contribute-code.html#writing-tests) section in the development guide.</sub>
   - repos:
       - pingcap/tidb-tools
       - pingcap/tidb-binlog

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -937,7 +937,7 @@ ti-community-format-checker:
         regexp: "\\\\n\\\\bTests <!-- At least one of them must be included\\\\. -->\\\\s*[\\\\n]{1,}(- \\\\[[xX ]\\\\] .*\\\\n)*(- \\\\[[xX]\\\\] .*\\\\n)(- \\\\[[xX ]\\\\] .*\\\\n)*\\\\n"
         missing_label: do-not-merge/needs-tests-checked
         missing_message: |
-          **Notice**: To remove the `do-not-merge/needs-finished-tests` label, please finished the test for the pull request and check the finished items in description.
+          **Notice**: To remove the `do-not-merge/needs-tests-checked` label, please finished the test for the pull request and check the finished items in description.
 
           For example:
 

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -935,7 +935,7 @@ ti-community-format-checker:
         body: true
         branches: [master]
         regexp: "\\\\n\\\\bTests <!-- At least one of them must be included\\\\. -->\\\\s*[\\\\n]{1,}(- \\\\[[xX ]\\\\] .*\\\\n)*(- \\\\[[xX]\\\\] .*\\\\n)(- \\\\[[xX ]\\\\] .*\\\\n)*\\\\n"
-        missing_label: do-not-merge/needs-finished-tests
+        missing_label: do-not-merge/needs-tests-checked
         missing_message: |
           **Notice**: To remove the `do-not-merge/needs-finished-tests` label, please finished the test for the pull request and check the finished items in description.
 

--- a/prow/config/labels.md
+++ b/prow/config/labels.md
@@ -493,7 +493,7 @@ larger set of contributors to apply/remove them.
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
 | <a id="do-not-merge/invalid-title" href="#do-not-merge/invalid-title">`do-not-merge/invalid-title`</a> | |  | |
-| <a id="do-not-merge/needs-finished-tests" href="#do-not-merge/needs-finished-tests">`do-not-merge/needs-finished-tests`</a> | |  | |
+| <a id="do-not-merge/needs-tests-checked" href="#do-not-merge/needs-tests-checked">`do-not-merge/needs-tests-checked`</a> | |  | |
 | <a id="do-not-merge/release-note-label-needed" href="#do-not-merge/release-note-label-needed">`do-not-merge/release-note-label-needed`</a> | Indicates that a PR should not merge because it's missing one of the release note labels.| prow |  [release-note](https://book.prow.tidb.net/#/en/plugins) |
 
 ## Labels that apply to pingcap/tiflow, for both issues and PRs

--- a/prow/config/labels.md
+++ b/prow/config/labels.md
@@ -493,6 +493,7 @@ larger set of contributors to apply/remove them.
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
 | <a id="do-not-merge/invalid-title" href="#do-not-merge/invalid-title">`do-not-merge/invalid-title`</a> | |  | |
+| <a id="do-not-merge/needs-finished-tests" href="#do-not-merge/needs-finished-tests">`do-not-merge/needs-finished-tests`</a> | |  | |
 | <a id="do-not-merge/release-note-label-needed" href="#do-not-merge/release-note-label-needed">`do-not-merge/release-note-label-needed`</a> | Indicates that a PR should not merge because it's missing one of the release note labels.| prow |  [release-note](https://book.prow.tidb.net/#/en/plugins) |
 
 ## Labels that apply to pingcap/tiflow, for both issues and PRs

--- a/prow/config/labels.yaml
+++ b/prow/config/labels.yaml
@@ -2794,6 +2794,9 @@ repos:
       - name: do-not-merge/needs-linked-issue
         color: "e11d21"
         target: both
+      - name: do-not-merge/needs-finished-tests
+        color: "e11d21"
+        target: prs
       - name: do-not-merge/invalid-title
         color: "e11d21"
         target: prs

--- a/prow/config/labels.yaml
+++ b/prow/config/labels.yaml
@@ -2794,7 +2794,7 @@ repos:
       - name: do-not-merge/needs-linked-issue
         color: "e11d21"
         target: both
-      - name: do-not-merge/needs-finished-tests
+      - name: do-not-merge/needs-tests-checked
         color: "e11d21"
         target: prs
       - name: do-not-merge/invalid-title


### PR DESCRIPTION
Signed-off-by: wuhuizuo <wuhuizuo@126.com>

<!-- Thank you for contributing -->

### What problem does this PR solve?

Problem Summary: blocking merging when pull request has none test tasks checked.

### What is changed and how it works?

What's Changed:

- add pull request format check rule on description for `pingcap/tidb`.
- add label `do-not-merge/needs-finished-tests` for `pingcap/tidb`.
- blocking merging when pull quest owned the `do-not-merge/needs-finished-tests` label

How it Works:

Check pull request description with format check external plugin.
