### PR TITLE
config: support lable ok-to-test on test-prod

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -42,6 +42,7 @@ ti-community-label:
     additional_labels:
       - "help wanted"
       - "good first issue"
+      - "ok-to-test"
   - repos:
       - ti-community-infra/rfcs
     prefixes:


### PR DESCRIPTION
support lable ok-to-test on test-prod.