### PR TITLE
fix(prow/config): fix comment template of `cherry_pick_unapproved` plugin

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -86,12 +86,12 @@ welcome:
 cherry_pick_unapproved:
   branchregexp: "^release-\\\\d+\\\\.\\\\d+$"
   comment: |
-    This cherry pick PR is for a release branch and has not yet been approved by release team.
-    Adding the `do-not-merge/cherry-pick-not-approved` label.
+    This cherry pick PR is for a release branch and has not yet been approved by triage owners. 
+    Adding the `do-not-merge/cherry-pick-not-approved` label. 
 
-    To merge this cherry pick, it must first be approved by the collaborators.
-
-    **AFTER** it has been approved by collaborators, please ping the release team in a comment to request a cherry pick review.
+    To merge this cherry pick:
+    1. It must be approved by the approvers firstly.
+    2. **AFTER** it has been approved by approvers, please wait for the cherry-pick merging approval from triage owners.
 
 size:
   s: 10

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -87,7 +87,7 @@ cherry_pick_unapproved:
   branchregexp: "^release-\\\\d+\\\\.\\\\d+$"
   comment: |
     This cherry pick PR is for a release branch and has not yet been approved by triage owners. 
-    Adding the `do-not-merge/cherry-pick-not-approved` label. 
+    Adding the `do-not-merge/cherry-pick-not-approved` label.
 
     To merge this cherry pick:
     1. It must be approved by the approvers firstly.


### PR DESCRIPTION
## Why

- Currently no delicated release team in PingCAP.
- Triage should be finished by triage owners rather than "release team".

Close #925
