### PR TITLE
fix(pingcap/ng-monitoring): enable builtin plugin `cherry-pick-unapproved`

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -424,6 +424,7 @@ plugins:
       - approve
       - assign
       - blunderbuss
+      - cherry-pick-unapproved
       - hold
       - lgtm
       - lifecycle


### PR DESCRIPTION
Signed-off-by: wuhuizuo <wuhuizuo@126.com>

<!-- Thank you for contributing -->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:
