### PR TITLE
Add a "MariaDB" label for tiflow repo

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -323,6 +323,7 @@ ti-community-label:
       - "question"
       - "release-blocker"
       - "wontfix"
+      - "MariaDB"
   - repos:
       - pingcap/tidb-binlog
     prefixes:


### PR DESCRIPTION
We are planning to focus on MariaDB upstream when migrating data to TiDB, add this issue label to better organize MariaDB-related issues