### PR TITLE
docs-cn/docs: add the "2024–tidb-docs-dash" label

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -231,6 +231,7 @@ ti-community-label:
       - "for-future-release"
       - "requires-version-specific-changes"
       - "website"
+      - "2024–tidb-docs-dash"
   - repos:
       - pingcap/docs-tidb-operator
     prefixes:

--- a/prow/config/labels.md
+++ b/prow/config/labels.md
@@ -243,6 +243,7 @@ larger set of contributors to apply/remove them.
 
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
+| <a id="2024–tidb-docs-dash" href="#2024–tidb-docs-dash">`2024–tidb-docs-dash`</a> | This issue or PR is included in the 2024 TiDB Docs Dash event.| anyone |  [ti-community-label](https://book.prow.tidb.net/#/en/plugins) |
 | <a id="closed/outdated" href="#closed/outdated">`closed/outdated`</a> | Closed because the PR is outdated.| anyone |  [ti-community-label](https://book.prow.tidb.net/#/en/plugins) |
 | <a id="for-future-release" href="#for-future-release">`for-future-release`</a> | This PR only applies to master for now and might cherry-pick to a future release.| anyone |  [ti-community-label](https://book.prow.tidb.net/#/en/plugins) |
 | <a id="hacktoberfest-accepted" href="#hacktoberfest-accepted">`hacktoberfest-accepted`</a> | This PR is accepted in Hacktoberfest.| anyone |  [ti-community-label](https://book.prow.tidb.net/#/en/plugins) |

--- a/prow/config/labels.md
+++ b/prow/config/labels.md
@@ -123,6 +123,7 @@ larger set of contributors to apply/remove them.
 
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
+| <a id="2024–tidb-docs-dash" href="#2024–tidb-docs-dash">`2024–tidb-docs-dash`</a> | This issue or PR is included in the 2024 TiDB Docs Dash event.| anyone |  [ti-community-label](https://book.prow.tidb.net/#/en/plugins) |
 | <a id="Hacktoberfest" href="#Hacktoberfest">`Hacktoberfest`</a> | This PR/issue is accepted in Hacktoberfest.| anyone |  [ti-community-label](https://book.prow.tidb.net/#/en/plugins) |
 | <a id="area/bigdata" href="#area/bigdata">`area/bigdata`</a> | Indicates that the Issue or PR belongs to the area of TiFlash, TiSpark, and OLAP.| anyone |  [ti-community-label](https://book.prow.tidb.net/#/en/plugins) |
 | <a id="area/br" href="#area/br">`area/br`</a> | Indicates that the Issue or PR belongs to the area of BR (Backup & Restore).| anyone |  [ti-community-label](https://book.prow.tidb.net/#/en/plugins) |
@@ -167,7 +168,6 @@ larger set of contributors to apply/remove them.
 
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
-| <a id="2024–tidb-docs-dash" href="#2024–tidb-docs-dash">`2024–tidb-docs-dash`</a> | This issue or PR is included in the 2024 TiDB Docs Dash event.| anyone |  [ti-community-label](https://book.prow.tidb.net/#/en/plugins) |
 | <a id="closed/outdated" href="#closed/outdated">`closed/outdated`</a> | Closed because the PR is outdated.| anyone |  [ti-community-label](https://book.prow.tidb.net/#/en/plugins) |
 | <a id="for-future-release" href="#for-future-release">`for-future-release`</a> | This PR only applies to master for now and might cherry-pick to a future release.| anyone |  [ti-community-label](https://book.prow.tidb.net/#/en/plugins) |
 | <a id="hacktoberfest-accepted" href="#hacktoberfest-accepted">`hacktoberfest-accepted`</a> | This PR is accepted in Hacktoberfest.| anyone |  [ti-community-label](https://book.prow.tidb.net/#/en/plugins) |
@@ -199,6 +199,7 @@ larger set of contributors to apply/remove them.
 
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
+| <a id="2024–tidb-docs-dash" href="#2024–tidb-docs-dash">`2024–tidb-docs-dash`</a> | This issue or PR is included in the 2024 TiDB Docs Dash event.| anyone |  [ti-community-label](https://book.prow.tidb.net/#/en/plugins) |
 | <a id="Hacktoberfest" href="#Hacktoberfest">`Hacktoberfest`</a> | This PR/issue is accepted in Hacktoberfest.| anyone |  [ti-community-label](https://book.prow.tidb.net/#/en/plugins) |
 | <a id="area/bigdata" href="#area/bigdata">`area/bigdata`</a> | Indicates that the Issue or PR belongs to the area of TiFlash, TiSpark, and OLAP.| anyone |  [ti-community-label](https://book.prow.tidb.net/#/en/plugins) |
 | <a id="area/br" href="#area/br">`area/br`</a> | Indicates that the Issue or PR belongs to the area of BR (Backup & Restore).| anyone |  [ti-community-label](https://book.prow.tidb.net/#/en/plugins) |
@@ -244,7 +245,6 @@ larger set of contributors to apply/remove them.
 
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
-| <a id="2024–tidb-docs-dash" href="#2024–tidb-docs-dash">`2024–tidb-docs-dash`</a> | This issue or PR is included in the 2024 TiDB Docs Dash event.| anyone |  [ti-community-label](https://book.prow.tidb.net/#/en/plugins) |
 | <a id="closed/outdated" href="#closed/outdated">`closed/outdated`</a> | Closed because the PR is outdated.| anyone |  [ti-community-label](https://book.prow.tidb.net/#/en/plugins) |
 | <a id="for-future-release" href="#for-future-release">`for-future-release`</a> | This PR only applies to master for now and might cherry-pick to a future release.| anyone |  [ti-community-label](https://book.prow.tidb.net/#/en/plugins) |
 | <a id="hacktoberfest-accepted" href="#hacktoberfest-accepted">`hacktoberfest-accepted`</a> | This PR is accepted in Hacktoberfest.| anyone |  [ti-community-label](https://book.prow.tidb.net/#/en/plugins) |

--- a/prow/config/labels.md
+++ b/prow/config/labels.md
@@ -167,6 +167,7 @@ larger set of contributors to apply/remove them.
 
 | Name | Description | Added By | Prow Plugin |
 | ---- | ----------- | -------- | --- |
+| <a id="2024–tidb-docs-dash" href="#2024–tidb-docs-dash">`2024–tidb-docs-dash`</a> | This issue or PR is included in the 2024 TiDB Docs Dash event.| anyone |  [ti-community-label](https://book.prow.tidb.net/#/en/plugins) |
 | <a id="closed/outdated" href="#closed/outdated">`closed/outdated`</a> | Closed because the PR is outdated.| anyone |  [ti-community-label](https://book.prow.tidb.net/#/en/plugins) |
 | <a id="for-future-release" href="#for-future-release">`for-future-release`</a> | This PR only applies to master for now and might cherry-pick to a future release.| anyone |  [ti-community-label](https://book.prow.tidb.net/#/en/plugins) |
 | <a id="hacktoberfest-accepted" href="#hacktoberfest-accepted">`hacktoberfest-accepted`</a> | This PR is accepted in Hacktoberfest.| anyone |  [ti-community-label](https://book.prow.tidb.net/#/en/plugins) |

--- a/prow/config/labels.yaml
+++ b/prow/config/labels.yaml
@@ -1296,6 +1296,13 @@ repos:
         prowPlugin: ti-community-label
         isExternalPlugin: true
         addedBy: anyone
+      - name: 2024–tidb-docs-dash
+        color: "#006b75"
+        description: This issue or PR is included in the 2024 TiDB Docs Dash event.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
       - name: type/cherry-pick-for-release-5.4
         color: "9ad662"
         description: This PR is cherry-picked to release-5.4 from a source PR.
@@ -1626,13 +1633,6 @@ repos:
         prowPlugin: ti-community-label
         isExternalPlugin: true
         addedBy: anyone
-      - name: 2024–tidb-docs-dash
-        color: "#006b75"
-        description: This issue or PR is included in the 2024 TiDB Docs Dash event.
-        target: prs
-        prowPlugin: ti-community-label
-        isExternalPlugin: true
-        addedBy: anyone
       - name: needs-cherry-pick-release-5.4
         color: "000000"
         description: Should cherry pick this PR to release-5.4 branch.
@@ -1782,6 +1782,13 @@ repos:
         description:
           Waits for a contributor to translate this PR and create a PR to the
           pingcap/docs-cn repository.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
+      - name: 2024–tidb-docs-dash
+        color: "#006b75"
+        description: This issue or PR is included in the 2024 TiDB Docs Dash event.
         target: prs
         prowPlugin: ti-community-label
         isExternalPlugin: true

--- a/prow/config/labels.yaml
+++ b/prow/config/labels.yaml
@@ -1299,7 +1299,7 @@ repos:
       - name: 2024–tidb-docs-dash
         color: "#006b75"
         description: This issue or PR is included in the 2024 TiDB Docs Dash event.
-        target: prs
+        target: both
         prowPlugin: ti-community-label
         isExternalPlugin: true
         addedBy: anyone
@@ -1789,7 +1789,7 @@ repos:
       - name: 2024–tidb-docs-dash
         color: "#006b75"
         description: This issue or PR is included in the 2024 TiDB Docs Dash event.
-        target: prs
+        target: both
         prowPlugin: ti-community-label
         isExternalPlugin: true
         addedBy: anyone

--- a/prow/config/labels.yaml
+++ b/prow/config/labels.yaml
@@ -1626,6 +1626,13 @@ repos:
         prowPlugin: ti-community-label
         isExternalPlugin: true
         addedBy: anyone
+      - name: 2024–tidb-docs-dash
+        color: "#006b75"
+        description: This issue or PR is included in the 2024 TiDB Docs Dash event.
+        target: prs
+        prowPlugin: ti-community-label
+        isExternalPlugin: true
+        addedBy: anyone
       - name: needs-cherry-pick-release-5.4
         color: "000000"
         description: Should cherry pick this PR to release-5.4 branch.


### PR DESCRIPTION
1. Add the `2024–tidb-docs-dash` label for the [pingcap/docs-cn](https://github.com/pingcap/docs-cn) and [pingcap/docs](https://github.com/pingcap/docs) repository. 
2. Support adding this label to a PR or issue by adding `/label 2024–tidb-docs-dash" in a comment of that PR or issue.