### PR TITLE
fix(tidb): fix merge commit message for cherry-pick pull requests

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -2193,7 +2193,7 @@ tide:
     pingcap/tidb:
       title: >-
         {{ .ExtractContent
-        "^(?P<content>.+?)(\\\\s+\\\\|(\\\\s+[-\\\\w]+=[-.\\\\w/]+)+)?\\\\s*$" .Title
+        "^(?P<content>.+?)(\\\\s+\\\\|(\\\\s+[-\\\\w]+=[-.\\\\w/]+)+)?\\\\s*(\\\\s+\\\\(#\\\\d+\\\\))*$" .Title
         }} (#{{ .Number }})
       body: |
         {{- $body := print .Body -}}


### PR DESCRIPTION
## Why
When the title of upstream pull request has suffix part acted as CI params, it will cause match missed and then the commit message will inherit the CI params parts.

## The PR will make some changes for merging with prow's tide component

### Not changed parts
When the origin title is: 
> scope: some title | tidb-test=pr/xxx

Then the merge commit message title of the origin PR will be:
> scope: some title (#1234)

Then the cherry-pick PR title is:
> scope: some title | tidb-test=pr/xxx (#1234)

`1234` is the origin PR number.

### Parts will be changed:
The merge commit message title of the cherry-pick PR currently is:
> scope: some title | tidb-test=pr/xxx (#1234) (#4567)

After the PR merged, it will be:
> scope: some title (#4567)

`4567` is the cherry-pick PR number.