### PR TITLE
add: close test-repo need-cherry-pick label

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -961,7 +961,7 @@ ti-community-issue-triage:
       - ti-community-infra/test-prod
     maintain_versions:
       - "7.5"
-    wontfix_versions: ["6.0"]
+    wontfix_versions: ["4.0", "5.0", "5.1", "5.2", "5.3", "5.4", "6.0", "6.1", "6.2", "6.3", "6.4", "6.5", "6.6", "7.0", "7.1", "7.2", "7.3", "7.4", "7.5", "7.6", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5", "8.6", "9.0", "9.1", "9.2"]
     affects_label_prefix: "affects/"
     may_affects_label_prefix: "may-affects/"
     linked_issue_needs_triage_label: "do-not-merge/needs-triage-completed"

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -1029,6 +1029,12 @@ external_plugins:
       events:
         - pull_request
         - issue_comment
+  ti-community-infra/test-prod:
+    - name: ti-community-cherrypicker
+      endpoint: http://prow-ti-community-cherrypicker
+      events:
+        - pull_request
+        - issue_comment
   pingcap/ng-monitoring:
     - name: needs-rebase
       endpoint: http://prow-needs-rebase


### PR DESCRIPTION
# Why
Disable the bot's automatic "need-cherry-pick" label to avoid too many PRs being created automatically. The related behavior will be moved to tirelease, where users can manually operate or use bot commands to add the "need-cherry-pick" label and create PRs as needed.

The PR is just for test
--------
# Not changed parts
The actions after adding the "need-cherry-pick" label remain the same, but the bot will no longer automatically add the label. However, if the user adds the "need-cherry-pick" label by other means, the bot will still create the corresponding PR as before, and its behavior will remain unchanged.