### PR TITLE
config: tidb-test add plugin lifecycle

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -499,6 +499,7 @@ plugins:
       - hold
       - label
       - lgtm
+      - lifecycle
       - owners-label
       - size
       - trigger


### PR DESCRIPTION
 tidb-test add plugin lifecycle to support close and reopen issue or PR by comments.
example:

> /close

it will request the bot to close the PR or issue, but the comment sender should be the PR/issue author or repo collaborator.