### PR TITLE
fix(prow/config): fix the color value for label `2024-tidb-docs-dash`

### DIFF
--- a/prow/config/labels.yaml
+++ b/prow/config/labels.yaml
@@ -1304,7 +1304,7 @@ repos:
         isExternalPlugin: true
         addedBy: anyone
       - name: 2024-tidb-docs-dash
-        color: "#006b75"
+        color: "006b75"
         description: This issue or PR is included in the 2024 TiDB Docs Dash event.
         target: both
         prowPlugin: ti-community-label


### PR DESCRIPTION
the wrong format make the cron job failed.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>

<!-- Thank you for contributing -->

### What problem does this PR solve?

Issue Number: ref #1005 <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

fix wrong value introduced by #1005

How it Works:
