### PR TITLE
fix(pingcap/monitoring): fill the cherry-pick config

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -756,6 +756,7 @@ ti-community-cherrypicker:
       - pingcap-inc/tiflash-scripts
       - PingCAP-QE/test-plan
       - PingCAP-QE/tidb-test
+      - pingcap/monitoring
       - pingcap/ng-monitoring
       - pingcap/tidb
       - pingcap/tidb-binlog


### PR DESCRIPTION

<!-- Thank you for contributing -->

### What problem does this PR solve?

Issue Number: ref https://github.com/ti-community-infra/configs/discussions/1030 <!-- REMOVE this line if no issue to close -->

Problem Summary:

The plugin is enabled, we must fill the config.


### What is changed and how it works?

What's Changed:
fill the config for `pingcap/monitoring` repository.

How it Works:
