### PR TITLE
fix(pingcap/docs-cn): delete context from branch protection rule

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1116,7 +1116,6 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
-                  - "pull"
                   - "license/cla"
                   - "pull-verify"
                   - "tide"


### PR DESCRIPTION
Why: the bot will guard for the Github action results.

But we need to watch it for few days.