### PR TITLE
config: remove tikv tide required context

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1354,13 +1354,6 @@ tide:
               release-8.1: *pd-branch-tide-context-options
               # release-{{.ver}}: *pd-branch-tide-context-options
 
-          tikv:
-            required-contexts:
-              - "DCO"
-              - "idc-jenkins-ci/test"
-              - "tide"
-            skip-unknown-contexts: true
-
       pingcap:
         repos:
           tidb-dashboard:

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1354,6 +1354,10 @@ tide:
               release-8.1: *pd-branch-tide-context-options
               # release-{{.ver}}: *pd-branch-tide-context-options
 
+          tikv:
+            from-branch-protection: true
+            skip-unknown-contexts: true
+
       pingcap:
         repos:
           tidb-dashboard:

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -101,7 +101,7 @@ branch-protection:
                 contexts:
                   - "DCO"
                   - "tide"
-                  - "idc-jenkins-ci/test"
+                  - "pull-unit-test"
                 strict: true
             release-5.4: &tikv-release-branch-pt
               protect: true

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -816,6 +816,7 @@ tide:
     pingcap/docs-cn: squash
     pingcap/docs-tidb-operator: squash
     pingcap/docs: squash
+    pingcap/kvproto: squash
     pingcap/monitoring: squash
     pingcap/ng-monitoring: squash
     pingcap/tidb-binlog: squash
@@ -825,11 +826,11 @@ tide:
     pingcap/tidb: squash
     pingcap/tiflash: squash
     pingcap/tiflow: squash
+    pingcap/tiproxy: squash
     pingcap/tispark: squash
     pingcap/tiunimanager-ui: squash
     pingcap/tiunimanager: squash
     pingcap/tiup: squash
-    pingcap/tiproxy: squash
     ti-community-infra/configs: squash
     ti-community-infra/rfcs: squash
     ti-community-infra/test-prod: squash
@@ -1161,6 +1162,7 @@ tide:
         - pingcap-inc/enterprise-extensions
         - pingcap-inc/enterprise-plugin
         - pingcap-inc/tiflash-scripts
+        - pingcap/kvproto
         - pingcap/monitoring
         - pingcap/ng-monitoring
         - pingcap/tidb

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -20,19 +20,20 @@ approve:
     ignore_review_state: true
     require_self_approval: true
     commandHelpLink: "https://prow.tidb.net/command-help"
-    pr_process_link: "https://book.prow.tidb.net/#/workflows/pr"    
+    pr_process_link: "https://book.prow.tidb.net/#/workflows/pr"
 lgtm:
   - repos: [pingcap, PingCAP-QE, pingcap-inc]
     review_acts_as_lgtm: true
     reviewer_count: 1
   - repos:
-      - pingcap/tidb
       - pingcap/docs
       - pingcap/docs-cn
       - pingcap/docs-tidb-operator
-      - pingcap/tiflow
+      - pingcap/kvproto
+      - pingcap/tidb
       - pingcap/tidb-binlog
       - pingcap/tiflash
+      - pingcap/tiflow
       - pingcap/tispark
     review_acts_as_lgtm: true
     reviewer_count: 2
@@ -46,6 +47,7 @@ owners:
     - pingcap/docs
     - pingcap/docs-cn
     - pingcap/docs-tidb-operator
+    - pingcap/kvproto
     - pingcap/monitoring
     - pingcap/ng-monitoring
     - pingcap/tidb
@@ -250,6 +252,19 @@ plugins:
       - trigger
       - verify-owners
       - welcome
+      - wip
+  pingcap/kvproto:
+    plugins:
+      - approve
+      - assign
+      - blunderbuss
+      - hold
+      - lgtm
+      - lifecycle
+      - owners-label
+      - size
+      - trigger
+      - verify-owners
       - wip
   pingcap/tidb-dashboard:
     plugins:
@@ -1211,7 +1226,7 @@ external_plugins:
       endpoint: http://prow-ti-community-cherrypicker
       events:
         - pull_request
-        - issue_comment        
+        - issue_comment
   pingcap-inc/tiflash-scripts:
     - name: needs-rebase
       endpoint: http://prow-needs-rebase


### PR DESCRIPTION
remove tikv tide required context because all context already set required in branch protect rules.