### PR TITLE
config(tiproxy): enable auto-merge for all branches

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1208,10 +1208,6 @@ tide:
     - repos:
         - pingcap/tiproxy
         # github query api index with `HasPrefix`.
-      includedBranches:
-        - main # trunk branch.
-        - feature/ # feature branches.
-        - release-
       labels:
         - lgtm
         - approved


### PR DESCRIPTION
Anable auto-merge to all branches of TiProxy.