### PR TITLE
refactor(tikv/pd, tikv/tikv): change the prow configuration for the `pd` and `tikv` repository

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -18,11 +18,8 @@ branch-protection:
                   - "DCO"
         pd:
           branches:
-            master:
+            master: &pd-release-branch-pt-with-6-chunks
               protect: true
-              required_pull_request_reviews:
-                require_code_owner_reviews: true
-                required_approving_review_count: 1
               required_status_checks:
                 contexts:
                   - "DCO"
@@ -104,20 +101,18 @@ branch-protection:
             release-7.5: *pd-release-branch-pt-with-13-chunks
             release-8.0: *pd-release-branch-pt-with-13-chunks
             release-8.1: *pd-release-branch-pt-with-13-chunks
-            # release-{{.ver}}: *pd-release-branch-pt-with-13-chunks
+            # release-{{.ver}}: *pd-release-branch-pt-with-6-chunks
 
         tikv:
           branches:
             master:
               protect: true
-              required_pull_request_reviews:
-                require_code_owner_reviews: true
               required_status_checks:
                 contexts:
                   - "DCO"
                   - "tide"
                   - "pull-unit-test"
-                strict: true
+                strict: false
             release-5.4: &tikv-release-branch-pt
               protect: true
               required_status_checks:
@@ -160,8 +155,6 @@ branch-protection:
           branches:
             master: &monitoring-branch-pt
               protect: true
-              required_pull_request_reviews:
-                require_code_owner_reviews: false
               required_status_checks:
                 contexts:
                   - "tide"
@@ -185,8 +178,6 @@ branch-protection:
           branches:
             main:
               protect: true
-              required_pull_request_reviews:
-                require_code_owner_reviews: false
               required_status_checks:
                 contexts:
                   - "tide"
@@ -285,8 +276,6 @@ branch-protection:
           branches:
             master:
               protect: true
-              required_pull_request_reviews:
-                require_code_owner_reviews: false
               required_status_checks:
                 contexts:
                   - "license/cla"
@@ -1056,8 +1045,6 @@ tide:
     # Notice: Because pingcap/tidb, tikv/tikv, tikv/pd repos enable the 'Require approvals' option on branch protection,
     #         we need to enable the 'reviewApprovedRequired' option on tide.
     - repos:
-        - tikv/tikv
-        - tikv/pd
         - tikv/community
       includedBranches:
         - master
@@ -1074,36 +1061,6 @@ tide:
         - do-not-merge/work-in-progress
         - needs-rebase
       reviewApprovedRequired: true
-    - repos:
-        - tikv/pd
-        - tikv/tikv
-      includedBranches: # release branches and hotFix branches
-        - release-5.4
-        - release-6. # release-6.x.y, release-6.x.y-*
-        - release-6.1 # LTS: avoid prow's "Merging to branch *** is forbidden" description issue.
-        - release-6.5 # LTS: avoid prow's "Merging to branch *** is forbidden" description issue.
-        - release-7. # release-7.x.y, release-7.x.y-*
-        - release-7.1 # LTS: avoid prow's "Merging to branch *** is forbidden" description issue.
-        - release-7.5 # LTS: avoid prow's "Merging to branch *** is forbidden" description issue.
-        - release-8. # release-8.x.y, release-8.x.y-*
-        - release-8.0 # DMR: avoid prow's "Merging to branch *** is forbidden" description issue.
-        - release-8.1 # LTS: avoid prow's "Merging to branch *** is forbidden" description issue.
-        # - release-{{.ver}}
-      labels:
-        - status/can-merge
-        # no need to query this label since
-        #   the `do-not-merge/cherry-pick-not-approved` label will be execluded.
-        # - cherry-pick-approved
-      missingLabels:
-        - do-not-merge/blocked-paths
-        - do-not-merge/cherry-pick-not-approved
-        - do-not-merge/hold
-        - do-not-merge/invalid-title
-        - do-not-merge/needs-linked-issue
-        - do-not-merge/needs-triage-completed
-        - do-not-merge/release-note-label-needed
-        - do-not-merge/work-in-progress
-        - needs-rebase
 
     # Repos which migrated to lgtm + approve plugins
     - repos:
@@ -1139,7 +1096,6 @@ tide:
         - release-7.1 # LTS: avoid prow's "Merging to branch *** is forbidden" description issue.
         - release-7.5 # LTS: avoid prow's "Merging to branch *** is forbidden" description issue.
         - release-8. # release-8.x.y, release-8.x.y-*
-        - release-8.0 # LTS: avoid prow's "Merging to branch *** is forbidden" description issue.
         - release-8.1 # LTS: avoid prow's "Merging to branch *** is forbidden" description issue.
         # - release-{{.ver}}
       labels:
@@ -1203,8 +1159,9 @@ tide:
         - pingcap/tiflash
         - pingcap/tiflow
         - pingcap/tispark
-        # github query api index with `HasPrefix`.
-      includedBranches:
+        - tikv/pd
+        - tikv/tikv
+      includedBranches: # github query api index with `HasPrefix`.
         - main # trunk branch.
         - master # trunk branch.
         - feature/ # feature branches.
@@ -1216,7 +1173,6 @@ tide:
         - release-7.5 # LTS: avoid prow's "Merging to branch *** is forbidden" description issue.
         - release-7. # release-7.x.y, release-7.x.y-*
         - release-8. # release-8.x.y, release-8.x.y-*
-        - release-8.0 # DMR: avoid prow's "Merging to branch *** is forbidden" description issue.
         - release-8.1 # LTS: avoid prow's "Merging to branch *** is forbidden" description issue.
         # - release-{{.ver}}
       labels:

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -5,25 +5,15 @@ command_help_link: https://prow.tidb.net/command-help
 ti-community-lgtm:
   - repos:
       - tikv/community
-      - tikv/pd
-      - tikv/tikv
     pull_owners_endpoint: http://prow-ti-community-owners/ti-community-owners
 
 ti-community-merge:
   - repos:
       - tikv/community
-      - tikv/pd
-      - tikv/tikv
     store_tree_hash: true
     pull_owners_endpoint: http://prow-ti-community-owners/ti-community-owners
 
 ti-community-owners:
-  - repos:
-      - tikv/pd
-      - tikv/tikv
-    use_github_permission: true
-    sig_endpoint: https://bots.tidb.io/ti-community-bot
-    require_lgtm_label_prefix: require-LGT
   - repos:
       - tikv/community
     default_require_lgtm: 1
@@ -476,20 +466,30 @@ ti-community-autoresponder:
     auto_responds:
       - regex: "(?mi)^/merge\\\\s*$"
         message: |
-          It seems you want to merge this PR, I will help you trigger all the tests:
+          We have migrated to builtin `LGTM` and `approve` plugins for reviewing.
+
+          👉 Please use `/approve` when you want approve this pull request.
+
+          > The changes announcement: [Proposal: Strengthen configuration change approval](https://internals.tidb.io/t/topic/906).
+
+      - regex: "(?mi)^/aprove\\\\s*$"
+        message: |
+          It seems you want to approve this PR, I will help you trigger all the tests:
 
           /run-all-tests
 
-          You only need to trigger `/merge` once, and if the CI test fails, you just re-trigger the test that failed and the bot will merge the PR for you after the CI passes.
+          - Currently the CI jobs are not prow job style, we need it to notify Jenkins server to run them.
+          - If the CI test fails, you just re-trigger the test that failed and the bot will merge the PR for you after the CI passes.
 
           > If you have any questions about the PR merge process, please refer to [pr process](https://book.prow.tidb.net/#/en/workflows/pr).
+
   - repos:
       - pingcap-inc/tiflash-scripts
       - pingcap/tiflash
     auto_responds:
       - regex: "(?mi)^/approve\\\\s*$"
         message: |
-          It seems you want to merge this PR, I will help you trigger all the tests:
+          It seems you want to approve this PR, I will help you trigger all the tests:
 
           /run-all-tests
 
@@ -521,29 +521,15 @@ ti-community-autoresponder:
         message: |
           We have migrated to builtin `LGTM` and `approve` plugins for reviewing.
 
-          Please use `/approve` when you want approve this pull request.
+          👉 Please use `/approve` when you want approve this pull request.
 
           > The changes announcement: [LGTM plugin changes](https://internals.tidb.io/t/topic/854)
-
-ti-community-blunderbuss:
-  - repos:
-      - tikv/pd
-    pull_owners_endpoint: http://prow-ti-community-owners/ti-community-owners
-    max_request_count: 2
-    include_reviewers:
-      # Tech Leaders
-      - rleungx
-      # Committers
-      - nolouch
-      - lhy1024
-      - JmPotato
-      - HuSharp
 
 ti-community-tars:
   - repos:
       - tikv/pd
       - tikv/tikv
-    only_when_label: "status/can-merge"
+    only_when_label: "lgtm"
     exclude_labels:
       - needs-rebase
       - do-not-merge/hold

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -3,7 +3,7 @@ approve:
     lgtm_acts_as_approve: true
     require_self_approval: true
     commandHelpLink: "https://prow.tidb.net/command-help"
-    pr_process_link: "https://book.prow.tidb.net/#/workflows/pr-old"
+    pr_process_link: "https://book.prow.tidb.net/#/workflows/pr"
   - repos: [pingcap, ti-community-infra, PingCAP-QE, pingcap-inc]
     lgtm_acts_as_approve: true
     require_self_approval: true
@@ -35,6 +35,8 @@ lgtm:
       - pingcap/tiflash
       - pingcap/tiflow
       - pingcap/tispark
+      - tikv/pd
+      - tikv/tikv
     review_acts_as_lgtm: true
     reviewer_count: 2
 owners:
@@ -64,6 +66,8 @@ owners:
     - pingcap/tiunimanager
     - pingcap/tiunimanager-ui
     - pingcap/tiup
+    - tikv/pd
+    - tikv/tikv
 
 welcome:
   - repos:
@@ -80,6 +84,7 @@ welcome:
       - pingcap/tiunimanager-ui
       - ti-community-infra
       - tikv/tikv
+      - tikv/pd
     message_template:
       "Welcome @{{.AuthorLogin}}! <br><br>It looks like this is your first PR to
       <a href='https://github.com/{{.Org}}/{{.Repo}}'>{{.Org}}/{{.Repo}}</a> 🎉.
@@ -611,27 +616,39 @@ plugins:
       - wip
   tikv/pd:
     plugins:
+      - approve
       - assign
       - cherry-pick-unapproved
       - hold
+      - lgtm
+      - lifecycle
+      - owners-label
       - release-note
       - require-matching-label
+      - retitle
       - size
       - trigger
+      - verify-owners
+      - welcome
       - wip
   tikv/tikv:
     plugins:
+      - approve
       - assign
-      - hold
-      - wip
-      - size
-      - trigger
-      - lifecycle
-      - welcome
       - cherry-pick-unapproved
-      - release-note
+      - hold
+      - lgtm
+      - lifecycle
       - milestone
       - milestoneapplier
+      - owners-label
+      - release-note
+      - retitle
+      - size
+      - trigger
+      - verify-owners
+      - welcome
+      - wip
 
   PingCAP-QE/ci: &ee-plugins
     plugins:
@@ -1300,17 +1317,6 @@ external_plugins:
       events:
         - pull_request
         - issue_comment
-    - name: ti-community-lgtm
-      endpoint: http://prow-ti-community-lgtm
-      events:
-        - pull_request_review
-        - pull_request
-    - name: ti-community-merge
-      endpoint: http://prow-ti-community-merge
-      events:
-        - issue_comment
-        - pull_request_review_comment
-        - pull_request
     - name: needs-rebase
       endpoint: http://prow-needs-rebase
       events:
@@ -1352,17 +1358,6 @@ external_plugins:
         - pull_request
         - issue_comment
   tikv/pd:
-    - name: ti-community-lgtm
-      endpoint: http://prow-ti-community-lgtm
-      events:
-        - pull_request_review
-        - pull_request
-    - name: ti-community-merge
-      endpoint: http://prow-ti-community-merge
-      events:
-        - issue_comment
-        - pull_request_review_comment
-        - pull_request
     - name: needs-rebase
       endpoint: http://prow-needs-rebase
       events:
@@ -1376,11 +1371,6 @@ external_plugins:
         - pull_request_review
         - pull_request
         - issues
-    - name: ti-community-blunderbuss
-      endpoint: http://prow-ti-community-blunderbuss
-      events:
-        - pull_request
-        - issue_comment
     - name: ti-community-tars
       endpoint: http://prow-ti-community-tars
       events:


### PR DESCRIPTION
What's Changed:

- replace "ti-community-lgtm" and "ti-community-merge" plugin with "lgtm" and "approve" plugins.
- update the auto response message for migration tips.
- update the branch protection rules for `pd` and `tikv` for migration.

Fixes #1064
Fixes #1063

Signed-off-by: wuhuizuo <wuhuizuo@126.com>