### PR TITLE
fix(tikv/pd): update branch protection rule for `master`

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -36,7 +36,7 @@ branch-protection:
                   - "chunks (6, MicroService Integration Test)"
                   - "tso-function-test"
                   - "idc-jenkins-ci/build"
-                strict: true
+                strict: false
             release-5.4:
               protect: true
               required_status_checks:


### PR DESCRIPTION
disable the "keep update with base branch" option for master branch in branch protection rule.

why:
1. the major CI job `pull-unit-test` will pre merge the code before run the tests, it will ensure the quality before merging.