### PR TITLE
config(pingcap/tidb-engine-ext): set tidb-engine-ext required context by tide

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1449,6 +1449,9 @@ tide:
           tiunimanager-ui:
             skip-unknown-contexts: true
             from-branch-protection: true
+          tidb-engine-ext:
+            skip-unknown-contexts: true
+            from-branch-protection: true
       pingcap-inc:
         repos:
           tiflash-scripts:


### PR DESCRIPTION
Add config for tidb-engine-ext required context by tide, use the default context inherited from branch protection.