### PR TITLE
chore(pingcap/tidb-tools): no need `ti-community-tar` plugin

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -617,7 +617,6 @@ ti-community-tars:
   - repos:
       - pingcap/tidb-operator
       - pingcap/tiup
-      - pingcap/tidb-tools
       - pingcap/tidb-dashboard
     only_when_label: "approved"
     exclude_labels:

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -990,11 +990,6 @@ external_plugins:
       endpoint: http://prow-ti-community-label-blocker
       events:
         - pull_request
-    - name: ti-community-tars
-      endpoint: http://prow-ti-community-tars
-      events:
-        - issue_comment
-        - push
     - name: ti-community-contribution
       endpoint: http://prow-ti-community-contribution
       events:


### PR DESCRIPTION
We have refactored the CI tasks to support pre-merge.

Signed-off-by: wuhuizuo <wuhuizuo@126.com>

<!-- Thank you for contributing -->

### What problem does this PR solve?

Issue Number: close #xxx <!-- REMOVE this line if no issue to close -->

Problem Summary:

### What is changed and how it works?

What's Changed:

How it Works:
