### PR TITLE
fix(tikv/tikv): update branch protections

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -241,7 +241,6 @@ branch-protection:
                 contexts:
                   - "dco"
                   - "tide"
-                  - "pull-unit-test"
                 strict: false
               restrictions: *branch-protection_restrictions
             # release-{{.ver}}: *tikv-release-branch-pt


### PR DESCRIPTION
### What is changed and how it works?

What's Changed:

change for the branches:
- release-8.5
- release-8.4
- release-8.3
- release-8.2
- release-8.1
- release-7.5
- release-7.1
- release-6.5

How it Works:

No need to add the required status checks for unit test job, because
the unit test job will be triggered by prow. It will check the results
before merge it.
