### PR TITLE
config(tiflow): ticdc skip-unknown-contexts

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1665,7 +1665,7 @@ tide:
             skip-unknown-contexts: true
             from-branch-protection: true
           ticdc:
-            skip-unknown-contexts: false
+            skip-unknown-contexts: true
             from-branch-protection: true
           tidb-binlog:
             skip-unknown-contexts: true


### PR DESCRIPTION
Currently, the ticdc repository does not require all GitHub Action tasks to run, so adjustments are being made to the configuration here.