### PR TITLE
config(ticdc): add build and ut as required context

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -610,6 +610,11 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
+                  - "Linux Build"
+                  - "Maintainer Unit Test"
+                  - "Coordinator Unit Test"
+                  - "Dispatcher Unit Test"
+                  - "Other Unit Tests"
                   - "license/cla"
                   # - "check-issue-triage-complete" # it should be enabled later.
                   - "tide"


### PR DESCRIPTION
Make build and ut as required contexts.