### PR TITLE
fix(pingcap/ticdc): add config for issue-triage plugin

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -1143,3 +1143,12 @@ ti-community-issue-triage:
     linked_issue_needs_triage_label: "do-not-merge/needs-triage-completed"
     need_cherry_pick_label_prefix: "needs-cherry-pick-release-"
     status_target_url: "https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/cherrypick-a-pr.html#pass-triage-complete-check"
+  - repos:
+      - pingcap/ticdc
+    maintain_versions: ["9.0"] # Add "{{.ver}}" only for LTS.
+    wontfix_versions: ["9.0", "9.1", "9.2"] # Add "{{.ver}}" # for EOS versions and DMR versions.
+    affects_label_prefix: "affects-"
+    may_affects_label_prefix: "may-affects-"
+    linked_issue_needs_triage_label: "do-not-merge/needs-triage-completed"
+    need_cherry_pick_label_prefix: "needs-cherry-pick-release-"
+    status_target_url: "https://pingcap.github.io/tidb-dev-guide/contribute-to-tidb/cherrypick-a-pr.html#pass-triage-complete-check"

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -198,8 +198,8 @@ dco:
     skip_dco_check_for_members: true
 
 triggers:
- - repos: [pingcap, tikv]
-   trigger_github_workflows: true
+  - repos: [pingcap, tikv]
+    trigger_github_workflows: true
 
 plugins:
   ti-community-infra/test-prod:


### PR DESCRIPTION
## try to solve the issue
![image](https://github.com/user-attachments/assets/a63669ad-40e9-453a-b385-7d7a01098dbe)

![image](https://github.com/user-attachments/assets/e8821265-54f6-4e1f-b6ca-2d46ba465910)

This pull request includes changes to the `prow/config/external_plugins_config.yaml` file to add configuration for the `pingcap/ticdc` repository. The most important changes are:

Configuration updates for `pingcap/ticdc` repository:

* Added `maintain_versions` with version "9.0".
* Added `wontfix_versions` with versions "9.0", "9.1", and "9.2".
* Added `affects_label_prefix` and `may_affects_label_prefix`.
* Added `linked_issue_needs_triage_label` and `need_cherry_pick_label_prefix`.
* Added `status_target_url` for triage completion check.
