### PR TITLE
config(ticdc): update required status

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -610,11 +610,6 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
-                  - "Linux Build"
-                  - "Maintainer Unit Test"
-                  - "Coordinator Unit Test"
-                  - "Dispatcher Unit Test"
-                  - "Other Unit Tests"
                   - "license/cla"
                   # - "check-issue-triage-complete" # it should be enabled later.
                   - "tide"


### PR DESCRIPTION
Remove some required statuses from the ticdc GitHub actions, as these tasks have been taken over by Prow. Tide will ensure that PRs are merged after the Prow jobs pass.