### PR TITLE
config(tikv/client-go): add additional required status checks for branch protection and update client-go settings

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -40,6 +40,9 @@ branch-protection:
               required_status_checks:
                 contexts:
                   - "tide"
+                  - "Unit Test / golangci"
+                  - "Unit Test / race-test"
+                  - "Unit Test / test"
                 strict: false
               restrictions: *branch-protection_restrictions
             tidb-9.0: *client-go-branch-pt
@@ -1676,6 +1679,10 @@ tide:
           tikv:
             from-branch-protection: true
             skip-unknown-contexts: true
+
+          client-go:
+            skip-unknown-contexts: true
+            from-branch-protection: true
 
       pingcap:
         repos:


### PR DESCRIPTION
This change will make Tide check whether the unit tests pass for the tikv/client-go repo, and the status of integration tests will not affect PR merges.