### PR TITLE
config(tikv/copr-test): add trigger plugin on tikv/copr-test

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -60,7 +60,6 @@ branch-protection:
               protect: true
               required_status_checks:
                 contexts:
-                  - "tide"
                   - "dco"
                   - "pull-integration-test"
                 strict: false

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -62,6 +62,7 @@ branch-protection:
                 contexts:
                   - "tide"
                   - "dco"
+                  - "pull-integration-test"
                 strict: false
               restrictions: *branch-protection_restrictions
             release-9.0-beta.1: *copr-test-branch-pt
@@ -1536,7 +1537,6 @@ tide:
         - pingcap/tiproxy
         - tikv/client-c
         - tikv/client-go
-        - tikv/copr-test
         - tikv/client-rust
         - tikv/raft-engine
         - tikv/rocksdb

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -740,6 +740,12 @@ plugins:
       - trigger
       - verify-owners
       - wip
+  tikv/copr-test:
+    plugins:
+      - hold
+      - size
+      - trigger
+      - wip
   tikv/client-rust:
     plugins:
       - approve
@@ -1352,6 +1358,12 @@ external_plugins:
         - pull_request
         - issue_comment
   tikv/client-go:
+    - name: ti-community-cherrypicker
+      endpoint: http://prow-ti-community-cherrypicker
+      events:
+        - pull_request
+        - issue_comment
+  tikv/copr-test:
     - name: ti-community-cherrypicker
       endpoint: http://prow-ti-community-cherrypicker
       events:


### PR DESCRIPTION
Add trigger plugin on tikv/copr-test, support for triggering prow job tasks after migration.