### PR TITLE
opt(tiflash): disable tars plugin

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -815,10 +815,10 @@ branch-protection:
                   - "tide"
                   - "check-issue-triage-complete"
                   - "license/cla"
-                strict: true
+                strict: false
               restrictions: *branch-protection_restrictions
             release-6.5: &tiflash-release-branch-pt
-              protect: true
+              protect: false
               required_status_checks:
                 contexts:
                   - "tide"

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -619,6 +619,7 @@ ti-community-tars:
       Your PR was out of date, I have automatically updated it for you.
 
       If the CI test fails, you just re-trigger the test that failed and the bot will merge the PR for you after the CI passes.
+
   - repos:
       - pingcap-inc/tiflash-scripts
       - pingcap/tidb-binlog
@@ -635,29 +636,6 @@ ti-community-tars:
       - do-not-merge/needs-triage-completed
     message: |
       Your PR was out of date, I have automatically updated it for you.
-
-      If the CI test fails, you just re-trigger the test that failed and the bot will merge the PR for you after the CI passes.
-
-  - repos:
-      - pingcap/tiflash
-    only_when_label: lgtm
-    exclude_labels:
-      - do-not-merge/hold
-      - do-not-merge/blocked-paths
-      - do-not-merge/work-in-progress
-      - do-not-merge/release-note-label-needed
-      - do-not-merge/cherry-pick-not-approved
-      - do-not-merge/needs-linked-issue
-      - do-not-merge/invalid-title
-      - do-not-merge/needs-triage-completed
-    message: |
-      Your PR was out of date, I have automatically updated it for you.
-
-      At the same time I will also trigger all tests for you:
-
-      /run-all-tests
-
-      > trigger some heavy tests which will not run always when PR updated.
 
       If the CI test fails, you just re-trigger the test that failed and the bot will merge the PR for you after the CI passes.
 

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -1149,11 +1149,6 @@ external_plugins:
       endpoint: http://prow-ti-community-format-checker
       events: [issues, pull_request]
   pingcap/tiflash:
-    - name: ti-community-tars
-      endpoint: http://prow-ti-community-tars
-      events:
-        - issue_comment
-        - push
     - name: ti-community-label
       endpoint: http://prow-ti-community-label
       events:


### PR DESCRIPTION
The core presubmit jobs for `tiflash` repo were refactored to prow style job, it will pre merge the codes before building or testing. So no need to enable the plugin to update branch for pull requests periodically in `tiflash` repo.

![image](https://github.com/user-attachments/assets/e606527d-6a84-4b3b-80f9-9e743fef94ac)
