### PR TITLE
chore(prow/config): remove stale comments in plugins.yaml

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -1,5 +1,5 @@
 approve:
-  - repos: [tikv] # repositories in tikv ORG are not migrated to LGTM and approve plugins.
+  - repos: [tikv]
     lgtm_acts_as_approve: true
     require_self_approval: true
     commandHelpLink: "https://prow.tidb.net/command-help"


### PR DESCRIPTION
This pull request includes a minor update to the `plugins.yaml` configuration file for the `approve` plugin. It removes a comment about the `tikv` organization repositories not being migrated, as it is no longer relevant.