### PR TITLE
chore(prow/config): remove 'idc-jenkins-ci/build' from branch protection contexts

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -112,7 +112,6 @@ branch-protection:
                   - "chunks (9, Microservice Integration(!TSO))"
                   - "chunks (10, Microservice Integration(TSO))"
                   - "tso-function-test"
-                  - "idc-jenkins-ci/build"
                 strict: false
               restrictions: *branch-protection_restrictions
             release-9.0-beta.1: *pd-release-branch-pt-with-tools-chunks
@@ -138,7 +137,6 @@ branch-protection:
                   - "chunks (9, MicroService Integration(!TSO))"
                   - "chunks (10, MicroService Integration(TSO))"
                   - "tso-function-test"
-                  - "idc-jenkins-ci/build"
                 strict: false
               restrictions: *branch-protection_restrictions
             release-8.4: *pd-release-branch-pt-with-tools-chunks-old
@@ -161,7 +159,6 @@ branch-protection:
                   - "chunks (9)"
                   - "chunks (10)"
                   - "tso-function-test"
-                  - "idc-jenkins-ci/build"
                 strict: true
               restrictions: *branch-protection_restrictions
             release-6.6: *pd-release-branch-pt-with-10-chunks
@@ -189,7 +186,6 @@ branch-protection:
                   - "chunks (12)"
                   - "chunks (13)"
                   - "tso-function-test"
-                  - "idc-jenkins-ci/build"
                 strict: true
               restrictions: *branch-protection_restrictions
             release-7.4: *pd-release-branch-pt-with-13-chunks
@@ -210,7 +206,6 @@ branch-protection:
                   - "chunks (5, TSO Integration Test)"
                   - "chunks (6, MicroService Integration Test)"
                   - "tso-function-test"
-                  - "idc-jenkins-ci/build"
                 strict: true
               restrictions: *branch-protection_restrictions
 
@@ -1543,7 +1538,6 @@ tide:
           pd:
             required-contexts:
               - "dco"
-              - "idc-jenkins-ci/build"
             skip-unknown-contexts: true
             branches:
               master: &pd-branch-tide-context-options-with-tools


### PR DESCRIPTION
This job js a prow style job, the prow tide component will automatically check it.
So, let's make the CI bot configuration be simpler.
