### PR TITLE
config(tikv/client-go): modify the configuration to let tide check all CI contexts.

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1613,10 +1613,6 @@ tide:
             from-branch-protection: true
             skip-unknown-contexts: true
 
-          client-go:
-            skip-unknown-contexts: true
-            from-branch-protection: true
-
           copr-test:
             skip-unknown-contexts: true
             from-branch-protection: true


### PR DESCRIPTION
# Why
The CI tasks of tikv/client-go are composed of GitHub Actions. There are two scenarios for checking CI context before merging a PR.
* Some necessary tests must be run; they cannot be temporarily skipped by human intervention: golangci & race-test & unit-test. These CI contexts are enforced to run successfully through branch protection rules, leaving no backdoor for skips.
* Some integration tests are expected to fail in specific scenarios, requiring manual setting of skip so that the PR can be merged normally. For example, when the integration test involves updating TiDB, there will be expected failures that need to be skipped first. Or some new integration tests are still in the testing phase, with expected failures.

# How
Tide currently supports automatic checks for all CI contexts. For CI that has already been triggered, it must run; if it fails, the merge will be blocked. However, GitHub Actions with a skip context ([Skip some GitHub Action run by a label](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#example-using-a-value-in-the-event-payload)) will not block the PR merge.