### PR TITLE
config(docs): add release-2.x for docs-tidb-operator

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1319,7 +1319,8 @@ tide:
       # github query api index with `HasPrefix`.
       includedBranches:
         - master # trunk branch.
-        - release-1. # release-1.2 ~ release-1.5 for docs-tidb-operator
+        - release-1. # release-1.2 ~ release-1.6 for docs-tidb-operator
+        - release-2. # release-2.0 for docs-tidb-operator
         - feature/v2 # feature branch for docs-tidb-operator
         - feature/ # preview branch
         - release-5. # keep before EOL at 2026.2


### PR DESCRIPTION
Add `release-2.x` branch pattern for [release-2.0](https://github.com/pingcap/docs-tidb-operator/tree/release-2.0)