### PR TITLE
feat(prow/configs): add prow-tekton external plugin to plugin config

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -916,6 +916,9 @@ external_plugins:
     - name: tekton-ee-cd
       endpoint: https://do.pingcap.net/tekton/hook
       events: [pull_request, push, create, release]
+    - name: prow-tekton
+      endpoint: http://el-public.ee-cd.svc:8080
+      events: [pull_request, push, create, release]
     - name: chatgpt
       endpoint: http://prow-chatgpt
       events:
@@ -1271,6 +1274,9 @@ external_plugins:
     - name: tekton-ee-cd
       endpoint: https://do.pingcap.net/tekton/hook
       events: [push, create, release]
+    - name: prow-tekton
+      endpoint: http://el-public.ee-cd.svc:8080
+      events: [push, create, release]
   pingcap-inc/enterprise-extensions:
     - name: ti-community-cherrypicker
       endpoint: http://prow-ti-community-cherrypicker
@@ -1314,6 +1320,9 @@ external_plugins:
   tikv:
     - name: tekton-ee-cd
       endpoint: https://do.pingcap.net/tekton/hook
+      events: [pull_request, push, create, release]
+    - name: prow-tekton
+      endpoint: http://el-public.ee-cd.svc:8080
       events: [pull_request, push, create, release]
     - name: chatgpt
       endpoint: http://prow-chatgpt


### PR DESCRIPTION
This pull request updates the `prow/config/plugins.yaml` file to add a new external plugin configuration for `prow-tekton` across multiple repositories. The changes ensure that the `prow-tekton` plugin is registered with appropriate endpoints and event triggers.

### External Plugin Configuration Updates:

* Added the `prow-tekton` plugin with the endpoint `http://el-public.ee-cd.svc:8080` and event triggers `[pull_request, push, create, release]` for the first repository configuration.
* Added the `prow-tekton` plugin with the same endpoint and event triggers `[push, create, release]` for the second repository configuration.
* Added the `prow-tekton` plugin with the endpoint and event triggers `[pull_request, push, create, release]` for the third repository configuration.