### PR TITLE
config(tidb-operator): remove jenkins-ci / pull-e2e-kind-v2 from branch protection checks

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -452,7 +452,6 @@ branch-protection:
                   - "lint"
                   - "unit"
                   - "verify"
-                  - "jenkins-ci / pull-e2e-kind-v2"
                   - "license/cla"
                   - "tide"
                 strict: true


### PR DESCRIPTION
Ref  https://github.com/PingCAP-QE/ci/pull/3744.

The new v2 pull-e2e pipeline is now in effect.