### PR TITLE
chore(prow/config): add nextgen label and update external plugins config

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -127,7 +127,7 @@ ti-community-label:
       - needs-cherry-pick-release-9.0-beta.2
       # - needs-cherry-pick-release-{{.ver}}
       - release-note
-      - require-LGT1
+      - nextgen
       - wontfix
       - affects-6.5
       - affects-7.1
@@ -203,25 +203,6 @@ ti-community-label:
       - impact
       - report
     additional_labels:
-      - "fuzz/sqlancer"
-      - "fuzz/comp"
-      - "challenge-program"
-      - "compatibility-breaker"
-      - "first-time-contributor"
-      - "contribution"
-      - "good first issue"
-      - "correctness"
-      - "duplicate"
-      - "proposal"
-      - "security"
-      - "needs-more-info"
-      - "needs-cherry-pick-release-6.5"
-      - "needs-cherry-pick-release-7.1"
-      - "needs-cherry-pick-release-7.5"
-      - "needs-cherry-pick-release-8.1"
-      - "needs-cherry-pick-release-8.5"
-      - "needs-cherry-pick-release-9.0-beta.2"
-      # - "needs-cherry-pick-release-{{.ver}}"
       - "affects-6.5"
       - "affects-7.1"
       - "affects-7.5"
@@ -229,12 +210,32 @@ ti-community-label:
       - "affects-8.5"
       - "affects-9.0"
       # - "affects-{{.ver}}"
+      - "challenge-program"
+      - "compatibility-breaker"
+      - "contribution"
+      - "correctness"
+      - "duplicate"
+      - "first-time-contributor"
+      - "fuzz/comp"
+      - "fuzz/sqlancer"
+      - "good first issue"
       - "may-affects-6.5"
       - "may-affects-7.1"
       - "may-affects-7.5"
       - "may-affects-8.1"
       - "may-affects-8.5"
       # - "may-affects-{{.ver}}"
+      - "needs-cherry-pick-release-6.5"
+      - "needs-cherry-pick-release-7.1"
+      - "needs-cherry-pick-release-7.5"
+      - "needs-cherry-pick-release-8.1"
+      - "needs-cherry-pick-release-8.5"
+      - "needs-cherry-pick-release-9.0-beta.2"
+      # - "needs-cherry-pick-release-{{.ver}}"
+      - "needs-more-info"
+      - "proposal"
+      - "security"
+      - nextgen
   - repos:
       - pingcap/docs
       - pingcap/docs-cn
@@ -357,33 +358,34 @@ ti-community-label:
       - impact
       - report
     additional_labels:
-      - "duplicate"
-      - "bug-from-internal-test"
-      - "bug-from-user"
-      - "affects-6.5"
-      - "affects-7.1"
-      - "affects-7.5"
-      - "affects-8.1"
-      - "affects-8.5"
-      - "affects-9.0"
+      - MariaDB
+      - affects-6.5
+      - affects-7.1
+      - affects-7.5
+      - affects-8.1
+      - affects-8.5
+      - affects-9.0
       # - "affects-{{.ver}}"
-      - "may-affects-6.5"
-      - "may-affects-7.1"
-      - "may-affects-7.5"
-      - "may-affects-8.1"
-      - "may-affects-8.5"
+      - bug-from-internal-test
+      - bug-from-user
+      - duplicate
+      - may-affects-6.5
+      - may-affects-7.1
+      - may-affects-7.5
+      - may-affects-8.1
+      - may-affects-8.5
       # - "may-affects-{{.ver}}"
-      - "needs-cherry-pick-release-6.5"
-      - "needs-cherry-pick-release-7.1"
-      - "needs-cherry-pick-release-7.5"
-      - "needs-cherry-pick-release-8.1"
-      - "needs-cherry-pick-release-8.5"
-      - "needs-cherry-pick-release-9.0-beta.2"
+      - needs-cherry-pick-release-6.5
+      - needs-cherry-pick-release-7.1
+      - needs-cherry-pick-release-7.5
+      - needs-cherry-pick-release-8.1
+      - needs-cherry-pick-release-8.5
+      - needs-cherry-pick-release-9.0-beta.2
       # - "needs-cherry-pick-release-{{.ver}}"
-      - "question"
-      - "release-blocker"
-      - "wontfix"
-      - "MariaDB"
+      - nextgen
+      - question
+      - release-blocker
+      - wontfix
   - repos:
       - pingcap/tidb-binlog
     prefixes:

--- a/prow/config/labels.yaml
+++ b/prow/config/labels.yaml
@@ -80,6 +80,11 @@
 # global affect to all matched repos in `.orgs` or `.repos` configurations.
 default:
   labels:
+    - name: nextgen
+      color: "c7def8"
+      description: Indicates that the Issue or PR belongs to the nextgen kernel architecture.
+      target: both
+      addedBy: anyone
     - name: cherry-pick-approved
       color: "1d8445"
       description: Cherry pick PR approved by release team.


### PR DESCRIPTION
This pull request updates label configurations for several repositories to improve consistency and add support for the new `nextgen` label. The main changes include adding the `nextgen` label to the global label set, updating its usage in the `ti-community-label` plugin configuration, and reorganizing the order of additional labels to improve readability and maintainability.

Label additions and updates:

* Added the `nextgen` label to the global label configuration in `labels.yaml`, with a description and color for issues and PRs related to the nextgen kernel architecture.
* Included the `nextgen` label in the `ti-community-label` plugin configuration for relevant repositories, both as a required label and in the list of additional labels. [[1]](diffhunk://#diff-910aba468e605d9219a6e9ce7684218cb1f8e7219a5f8e2abf0a13b5f3f45c3aL130-R130) [[2]](diffhunk://#diff-910aba468e605d9219a6e9ce7684218cb1f8e7219a5f8e2abf0a13b5f3f45c3aL206-R238) [[3]](diffhunk://#diff-910aba468e605d9219a6e9ce7684218cb1f8e7219a5f8e2abf0a13b5f3f45c3aL360-R388)

Label organization and consistency:

* Reordered and regrouped existing labels in the `additional_labels` section for better clarity and maintainability, ensuring labels are consistently listed and no duplicates exist. [[1]](diffhunk://#diff-910aba468e605d9219a6e9ce7684218cb1f8e7219a5f8e2abf0a13b5f3f45c3aL206-R238) [[2]](diffhunk://#diff-910aba468e605d9219a6e9ce7684218cb1f8e7219a5f8e2abf0a13b5f3f45c3aL360-R388)
