### PR TITLE
chore(prow/config): forward issue_comment events to tekton svc

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -1508,7 +1508,7 @@ external_plugins:
       events: [push, create, release]
     - name: prow-tekton
       endpoint: http://el-github.ee-cd.svc:8080
-      events: [push, create, release]
+      events: [push, create, release, issue_comment]
     - name: cherrypicker
       endpoint: http://prow-cherrypicker
       events: [issue_comment, pull_request]


### PR DESCRIPTION
This pull request makes a small update to the `prow-tekton` plugin configuration in `prow/config/plugins.yaml`, expanding the list of events that trigger the plugin.

* Added `issue_comment` to the `events` list for the `prow-tekton` plugin, allowing it to respond to issue comments in addition to pushes, creates, and releases.