### PR TITLE
test: Add cherry-pick plugins to test-prod repo

### DIFF
--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -158,6 +158,12 @@ cherry_pick_approved:
     approvers:
       - bb7133
       - djshow832
+
+  - <<: *base_tidbx_cp_approve
+    repo: ti-community-infra/test-prod
+    approvers:
+      - wuhuizuo
+      - lybcodes
 cherry_pick_unapproved:
   branchregexp: "^release-((nextgen|tidbx)-[0-9]{8}|[0-9]+[.][0-9]+(-(beta|rc)[.][0-9]+)?)$"
   comment: |
@@ -265,6 +271,8 @@ plugins:
       - assign
       - blunderbuss
       - branchcleaner
+      - cherry-pick-approved
+      - cherry-pick-unapproved
       - help
       - hold
       - lgtm


### PR DESCRIPTION
Add wuhuizuo and lybcodes as approvers for cherry-pick-approved in test-prod repo and enable plugins for the repository