### PR TITLE
chore(prow/config): update tide config for tidb-operator main branch

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1662,6 +1662,11 @@ tide:
           tidb-operator:
             from-branch-protection: true
             skip-unknown-contexts: true
+            branches:
+              main:
+                from-branch-protection: false
+                skip-unknown-contexts: false
+
           tiup:
             from-branch-protection: true
             skip-unknown-contexts: false


### PR DESCRIPTION
Override default settings for main branch in TiDB Operator, switch to the most strict mode.