### PR TITLE
chore: remove affects-9.0 label config

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -134,7 +134,6 @@ ti-community-label:
       - affects-7.5
       - affects-8.1
       - affects-8.5
-      - affects-9.0
       # - affects-{{.ver}}
       - may-affects-6.5
       - may-affects-7.1
@@ -178,7 +177,6 @@ ti-community-label:
       - affects-7.5
       - affects-8.1
       - affects-8.5
-      - affects-9.0
       # - affects-{{.ver}}
       - may-affects-6.5
       - may-affects-7.1
@@ -208,7 +206,6 @@ ti-community-label:
       - "affects-7.5"
       - "affects-8.1"
       - "affects-8.5"
-      - "affects-9.0"
       # - "affects-{{.ver}}"
       - "challenge-program"
       - "compatibility-breaker"
@@ -366,7 +363,6 @@ ti-community-label:
       - affects-7.5
       - affects-8.1
       - affects-8.5
-      - affects-9.0
       # - "affects-{{.ver}}"
       - bug-from-internal-test
       - bug-from-user
@@ -449,7 +445,6 @@ ti-community-label:
       - "affects-7.5"
       - "affects-8.1"
       - "affects-8.5"
-      - "affects-9.0"
       # - "affects-{{.ver}}"
       - "may-affects-6.5"
       - "may-affects-7.1"

--- a/prow/config/labels.yaml
+++ b/prow/config/labels.yaml
@@ -257,9 +257,6 @@ default:
       color: "e11d21"
       description: This bug affects the 8.5.x(LTS) versions.
       target: issues
-    - name: affects-9.0
-      color: "e11d21"
-      description: This bug affects the 9.0.x versions.
       target: issues
     ## Please update or create it when new DMR is comming.
     # - name: affects-{{.ver}}


### PR DESCRIPTION
This PR removes the `affects-9.0` label configuration from the following files:

1. `prow/config/external_plugins_config.yaml`
2. `prow/config/labels.yaml`

The label is no longer needed and has been removed from all relevant configurations.