### PR TITLE
fix(prow/config): update tide query labels for `pingcap-qe/ci` repo

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1534,7 +1534,6 @@ tide:
     - repos:
         - PingCAP-QE/automated-tests
         - PingCAP-QE/benchbot
-        - PingCAP-QE/ci
         - PingCAP-QE/endless
         - PingCAP-QE/qa
         - PingCAP-QE/test-infra
@@ -1552,11 +1551,15 @@ tide:
         - do-not-merge/invalid-commit-message
         - do-not-merge/invalid-owners-file
         - do-not-merge/work-in-progress
+
     - repos:
+        - PingCAP-QE/ci
         - PingCAP-QE/artifacts
         - PingCAP-QE/ee-ops
         - PingCAP-QE/ee-apps
       labels:
+        # long-term: there will only be single engineering approver for a domain.
+        # For now, we only have single active expert for the CI/CD domain.
         - approved
       missingLabels:
         - do-not-merge

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -112,8 +112,7 @@ welcome:
       - tikv/rocksdb
       - tikv/rust-rocksdb
       - tikv/tikv
-    message_template:
-      "Welcome @{{.AuthorLogin}}! <br><br>It looks like this is your first PR to
+    message_template: "Welcome @{{.AuthorLogin}}! <br><br>It looks like this is your first PR to
       <a href='https://github.com/{{.Org}}/{{.Repo}}'>{{.Org}}/{{.Repo}}</a> 🎉.
       <br><br>I'm the bot to help you request reviewers, add labels and more,
       See [available commands](https://prow.tidb.net/command-help). <br><br>We
@@ -1066,10 +1065,6 @@ external_plugins:
       events:
         - pull_request
         - issue_comment
-    - name: product-jenkins
-      endpoint: https://do.pingcap.net/jenkins/generic-webhook-trigger/invoke
-      events:
-        - pull_request
   pingcap/docs: &docs-ext-plugins
     - name: ti-community-autoresponder
       endpoint: http://prow-ti-community-autoresponder


### PR DESCRIPTION
Make it only need `approved` label to join the merging pool.