### PR TITLE
fix(tide): move release-fts- into feature includedBranches

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1399,7 +1399,6 @@ tide:
       includedBranches: # github query api index with `HasPrefix`.
         - main # trunk branch.
         - master # trunk branch.
-        - release-fts- # fts release branches.
         - release-nextgen- # next-gen release branches.
         - release-7.1 # LTS: avoid prow's "Merging to branch *** is forbidden" description issue.
         - release-7.5 # LTS: avoid prow's "Merging to branch *** is forbidden" description issue.
@@ -1450,6 +1449,7 @@ tide:
       includedBranches: # github query api index with `HasPrefix`.
         - feature/tidb-zero
         - feature/ # feature branches.
+        - release-fts- # fts release branches.
       labels:
         - lgtm
       missingLabels:


### PR DESCRIPTION
This pull request updates the branch inclusion list for the Tide merge automation configuration. The main change is the repositioning of the `release-fts-` branch pattern within the `includedBranches` list, which affects how pull requests targeting these branches are handled by the automation.

Branch inclusion list adjustments:

* Moved the `release-fts-` branch pattern from the first `includedBranches` section (main/master/nextgen/LTS) to the second section (feature branches), ensuring that FTS release branches are grouped with feature branches for Tide processing. [[1]](diffhunk://#diff-d4833a025b8610abdf4b2856fd24cbe3f18b4ef2708398719880dcca773d1d7dL1402) [[2]](diffhunk://#diff-d4833a025b8610abdf4b2856fd24cbe3f18b4ef2708398719880dcca773d1d7dR1452)