### PR TITLE
prow(format-checker): add PR title checks for PingCAP-QE repos

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1584,6 +1584,21 @@ tide:
 
     - repos:
         - PingCAP-QE/ci
+      labels:
+        # long-term: there will only be single engineering approver for a domain.
+        # For now, we only have single active expert for the CI/CD domain.
+        - approved
+      missingLabels:
+        - do-not-merge
+        - do-not-merge/blocked-paths
+        - do-not-merge/contains-merge-commits
+        - do-not-merge/hold
+        - do-not-merge/invalid-commit-message
+        - do-not-merge/invalid-title
+        - do-not-merge/invalid-owners-file
+        - do-not-merge/work-in-progress
+
+    - repos:
         - PingCAP-QE/artifacts
         - PingCAP-QE/ee-ops
         - PingCAP-QE/ee-apps

--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1584,21 +1584,6 @@ tide:
 
     - repos:
         - PingCAP-QE/ci
-      labels:
-        # long-term: there will only be single engineering approver for a domain.
-        # For now, we only have single active expert for the CI/CD domain.
-        - approved
-      missingLabels:
-        - do-not-merge
-        - do-not-merge/blocked-paths
-        - do-not-merge/contains-merge-commits
-        - do-not-merge/hold
-        - do-not-merge/invalid-commit-message
-        - do-not-merge/invalid-title
-        - do-not-merge/invalid-owners-file
-        - do-not-merge/work-in-progress
-
-    - repos:
         - PingCAP-QE/artifacts
         - PingCAP-QE/ee-ops
         - PingCAP-QE/ee-apps
@@ -1612,6 +1597,7 @@ tide:
         - do-not-merge/contains-merge-commits
         - do-not-merge/hold
         - do-not-merge/invalid-commit-message
+        - do-not-merge/invalid-title
         - do-not-merge/invalid-owners-file
         - do-not-merge/work-in-progress
 

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -802,12 +802,15 @@ ti-community-format-checker:
           :rightwards_hand: $${\\color{gold}\\Huge{\\textsf{Please use english to create or update issue.}}}$$
   - repos:
       - PingCAP-QE/ci
+      - PingCAP-QE/artifacts
+      - PingCAP-QE/ee-ops
+      - PingCAP-QE/ee-apps
     required_match_rules:
       - pull_request: true
         title: true
-        regexp: "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|jobs|pipelines|prow|security|tekton|tools)(\\([[:alnum:]_.\\/-]+\\))?(!)?: [^[:space:]].{0,159}$"
+        regexp: "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([[:alnum:]_.\\/-]+\\))?(!)?: [^[:space:]].{0,159}$"
         missing_message: |
-          **Notice**: To remove the `do-not-merge/invalid-title` label, please use a Conventional Commits style PR title.
+          **Notice**: To remove the `do-not-merge/invalid-title` label, please use a [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style PR title, for example `type: description` or `type(scope): description`.
 
           Examples:
           - `ci(prow): add PR title lint`

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -801,6 +801,19 @@ ti-community-format-checker:
         missing_message: >-
           :rightwards_hand: $${\\color{gold}\\Huge{\\textsf{Please use english to create or update issue.}}}$$
   - repos:
+      - PingCAP-QE/ci
+    required_match_rules:
+      - pull_request: true
+        title: true
+        regexp: "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([[:alnum:]_.\\/-]+\\))?(!)?: [^[:space:]].{0,159}$"
+        missing_message: |
+          **Notice**: To remove the `do-not-merge/invalid-title` label, please use a Conventional Commits style PR title.
+
+          Examples:
+          - `ci(prow): add PR title lint`
+          - `docs: update contributing guide`
+        missing_label: do-not-merge/invalid-title
+  - repos:
       - pingcap/tidb-tools
       - pingcap/tidb-binlog
     required_match_rules:

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -805,7 +805,7 @@ ti-community-format-checker:
     required_match_rules:
       - pull_request: true
         title: true
-        regexp: "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([[:alnum:]_.\\/-]+\\))?(!)?: [^[:space:]].{0,159}$"
+        regexp: "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test|jobs|pipelines|prow|security|tekton|tools)(\\([[:alnum:]_.\\/-]+\\))?(!)?: [^[:space:]].{0,159}$"
         missing_message: |
           **Notice**: To remove the `do-not-merge/invalid-title` label, please use a Conventional Commits style PR title.
 

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -1681,11 +1681,17 @@ external_plugins:
     - name: tekton2-ee-cd
       endpoint: https://do2.pingcap.net/tekton/hook
       events: [pull_request, push, create, release]
-  PingCAP-QE/ci: &ee-ext-plugins
+  PingCAP-QE/ci:
     - name: chatgpt
       endpoint: http://prow-chatgpt
       events: [issue_comment, pull_request]
-  PingCAP-QE/ee-apps: *ee-ext-plugins
+    - name: ti-community-format-checker
+      endpoint: http://prow-ti-community-format-checker
+      events: [issues, pull_request]
+  PingCAP-QE/ee-apps: &ee-ext-plugins
+    - name: chatgpt
+      endpoint: http://prow-chatgpt
+      events: [issue_comment, pull_request]
   PingCAP-QE/ee-ops: *ee-ext-plugins
   PingCAP-QE/benchbot: []
   PingCAP-QE/endless: []

--- a/prow/config/plugins.yaml
+++ b/prow/config/plugins.yaml
@@ -1675,23 +1675,23 @@ external_plugins:
     - name: chatgpt
       endpoint: http://prow-chatgpt
       events: [issue_comment, pull_request]
+    - name: ti-community-format-checker
+      endpoint: http://prow-ti-community-format-checker
+      events: [issues, pull_request]
     - name: tekton-ee-cd
       endpoint: https://do.pingcap.net/tekton/hook
       events: [pull_request, push, create, release]
     - name: tekton2-ee-cd
       endpoint: https://do2.pingcap.net/tekton/hook
       events: [pull_request, push, create, release]
-  PingCAP-QE/ci:
+  PingCAP-QE/ci: &ee-ext-plugins
     - name: chatgpt
       endpoint: http://prow-chatgpt
       events: [issue_comment, pull_request]
     - name: ti-community-format-checker
       endpoint: http://prow-ti-community-format-checker
       events: [issues, pull_request]
-  PingCAP-QE/ee-apps: &ee-ext-plugins
-    - name: chatgpt
-      endpoint: http://prow-chatgpt
-      events: [issue_comment, pull_request]
+  PingCAP-QE/ee-apps: *ee-ext-plugins
   PingCAP-QE/ee-ops: *ee-ext-plugins
   PingCAP-QE/benchbot: []
   PingCAP-QE/endless: []


### PR DESCRIPTION
## Summary

Enable PR title validation for `PingCAP-QE/ci、PingCAP-QE/artifacts、PingCAP-QE/ee-ops、PingCAP-QE/ee-apps` using the existing `ti-community-format-checker` plugin.

## Changes

- register `ti-community-format-checker` for `PingCAP-QE/ci、PingCAP-QE/artifacts、PingCAP-QE/ee-ops、PingCAP-QE/ee-apps`
- add a Conventional Commits style title rule
- gate merges on `do-not-merge/invalid-title`