### PR TITLE
prow(format-checker): fix title regexp YAML quoting

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -808,7 +808,7 @@ ti-community-format-checker:
     required_match_rules:
       - pull_request: true
         title: true
-        regexp: "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([[:alnum:]_.\\/-]+\\))?(!)?: [^[:space:]].{0,159}$"
+        regexp: '^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)([(][[:alnum:]_./-]+[)])?(!)?: [^[:space:]].{0,159}$'
         missing_message: |
           **Notice**: To remove the `do-not-merge/invalid-title` label, please use a [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style PR title, for example `type: description` or `type(scope): description`.
 


### PR DESCRIPTION
## Fix

- switch the regexp to a single-quoted YAML string
- avoid `\(` and `\)` by using literal bracket expressions for scope parentheses
- keep the same Conventional Commits validation behavior

## Validation

- verified `prow/config/external_plugins_config.yaml` can be loaded by a local YAML parser
- verified positive and negative title examples against the parsed regexp
- verified `kubectl create configmap --dry-run=client` renders the updated rule without YAML escape errors
