### PR TITLE
chore(prow):  update branch protection merge checks for the tikv/client-c

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -22,7 +22,6 @@ branch-protection:
                 contexts:
                   - "tide"
                   - "DCO"
-                  - "idc-jenkins-ci/test"
                 strict: true
               restrictions: *branch-protection_restrictions
             release-9.0: *client-c-branch-pt


### PR DESCRIPTION
[idc-jenkins-ci/test](https://ci.pingcap.net/job/tikv_client_c_ghpr_test/457/display/redirect) has been refactor to github action and disabled, remove this check item.