### PR TITLE
fix(prow/config): support multiple scopes in PR title regex for PingCAP-QE/* repos 

### DIFF
--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -809,7 +809,7 @@ ti-community-format-checker:
     required_match_rules:
       - pull_request: true
         title: true
-        regexp: "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)([(][[:alnum:]_./-]+[)])?(!)?: [^[:space:]].{0,159}$"
+        regexp: "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)([(][[:alnum:]_./-]+([,][[:alnum:]_./-]+)*[)])?(!)?: [^[:space:]].{0,159}$"
         missing_message: |
           **Notice**: To remove the `do-not-merge/invalid-title` label, please use a [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style PR title, for example `type: description` or `type(scope): description`.
 

--- a/prow/config/external_plugins_config.yaml
+++ b/prow/config/external_plugins_config.yaml
@@ -813,7 +813,7 @@ ti-community-format-checker:
         title: true
         regexp: "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)([(][[:alnum:]_./-]+([,][[:alnum:]_./-]+)*[)])?(!)?: [^[:space:]].{0,159}$"
         missing_message: |
-          **Notice**: To remove the `do-not-merge/invalid-title` label, please use a [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style PR title, for example `type: description` or `type(scope): description`.
+          **Notice**: To remove the `do-not-merge/invalid-title` label, please use a [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) style PR title, for example `type: description`, `type(scope): description`, or `type(scope1,scope2): description`.
 
           Examples:
           - `ci(prow): add PR title lint`


### PR DESCRIPTION
Allow comma-separated multiple scopes in the conventional commit PR title lint rule for `PingCAP-QE` repos.

**Before:** `([(][[:alnum:]_./-]+[)])?` — only single scope, e.g. `feat(api): ...`
**After:** `([(][[:alnum:]_./-]+([,][[:alnum:]_./-]+)*[)])?` — supports multiple scopes, e.g. `feat(api,ui): ...`

All existing patterns (no scope, single scope, breaking `!`) continue to work.