### PR TITLE
chore(prow): remove release-6.1 tide exclusions

### DIFF
--- a/prow/config/config.yaml
+++ b/prow/config/config.yaml
@@ -1498,9 +1498,7 @@ tide:
         # github query api index with `HasPrefix`.
       excludedBranches:
         # patched release branches.
-        - release-6.1
         - release-6.5
-        - release-6.1.
         - release-6.5.
         - release-7.1.
         - release-7.5.


### PR DESCRIPTION
## Summary
- remove `release-6.1` and `release-6.1.` from the Tide `excludedBranches` list for `PingCAP-QE/tidb-test`
- keep the remaining maintained release branch exclusions unchanged
- leave label config untouched because no live `6.1` label entries remain in `prow/config`

## Companion PR
- PingCAP-QE/ci: https://github.com/PingCAP-QE/ci/pull/4710

## Validation
- `rg -n "affects-6\.1|may-affects-6\.1|needs-cherry-pick-release-6\.1|type/cherry-pick-for-release-6\.1|release-6\.1($|\.)|release-6\.1-|feature/release-6\.1\.[0-9]+|v6\.1\.[0-9]+" prow/config`